### PR TITLE
docs: add canonical portfolio design foundation

### DIFF
--- a/docs/design/00-overview.md
+++ b/docs/design/00-overview.md
@@ -1,0 +1,132 @@
+# Portfolio Design Foundation
+
+## Status
+
+This design foundation is **canonical and locked**.
+
+The portfolio is not a gallery of independent projects. It is a guided tour through one evolving body of work: intelligent systems that remove friction from everyday life.
+
+Jarvis is the orchestrator, AI-Lab is the workshop, and each agent is a specialized capability within the same long-term pursuit.
+
+## North Star
+
+> Everyday life, thoughtfully automated.
+
+John Moses builds connected systems for time, travel, health, and the small decisions that shape a day.
+
+The portfolio should communicate:
+
+> This person does not just write code. He builds systems.
+
+The emotional memory to leave with visitors is:
+
+> John notices the invisible friction in everyday life—and cares enough to build calm, thoughtful systems that make it disappear.
+
+## Canonical Decisions
+
+### Product position
+
+**Make the ecosystem the portfolio.**
+
+- Promise: Everyday life, thoughtfully automated.
+- Proof: Connected systems, not isolated demos.
+- Personality: Precision with warmth.
+
+### Creative direction
+
+**The Luminous Workshop**
+
+> A quiet room. A precise instrument. Evidence of a curious person at work.
+
+The future is present, but it has been made calm enough to examine.
+
+The visual identity combines:
+
+- 70% Quiet Intelligence: layout, type, pacing, hierarchy, and restraint.
+- 20% Human Systems Journal: voice, annotations, warmth, artifacts, and pixel lineage.
+- 10% Systems Observatory: the signature ecosystem map and orchestration sequence only.
+
+### Canonical visual metaphor
+
+**The Long Table**
+
+> It feels like walking beside one uninterrupted workbench where a decade of intelligent systems is being assembled in plain sight.
+
+The Long Table is translated digitally through alignment, accumulation, material contrast, and spatial progression—not through a literal table photograph or a 3D environment.
+
+- Table becomes a persistent horizontal datum.
+- Walking becomes vertical narrative progression.
+- Objects become evidence with provenance.
+- Instrument becomes the active ecosystem plane.
+- Accumulation becomes visible iteration and history.
+
+### Homepage narrative
+
+```text
+Arrival
+  ↓
+Discovery
+  ↓
+Understanding
+  ↓
+Evidence
+  ↓
+Judgment
+  ↓
+Person
+  ↓
+Invitation
+```
+
+Every chapter is necessary:
+
+- No arrival means no thesis.
+- No discovery means no ecosystem.
+- No understanding means no orchestration.
+- No evidence means no proof.
+- No judgment means no seniority.
+- No person means no warmth.
+- No invitation means no continuation.
+
+## Canonical System Model
+
+```mermaid
+flowchart TD
+    Intent["Human intent"] --> Jarvis["Jarvis<br/>Intent · Context · Orchestration"]
+
+    Jarvis --> Daily["Daily Intelligence"]
+    Jarvis --> Time["Time"]
+    Jarvis --> Movement["Movement"]
+    Jarvis --> Wellbeing["Wellbeing"]
+
+    Daily --> Morning["Morning Briefing Agent"]
+    Time --> Calendar["Calendar Agent"]
+    Time --> Reminder["Reminder Agent"]
+    Movement --> Flight["Flight Agent"]
+    Wellbeing --> Nutrition["Nutrition Agent"]
+    Wellbeing --> Health["Health Agent"]
+
+    Foundation["Shared context · Memory · Trust · Automation boundaries · Design principles"] --- Jarvis
+```
+
+Jarvis is not a project card, mascot, chatbot, or global navigation control. Jarvis is the coordinating layer that interprets intent, carries context, and makes the relationships between specialized capabilities legible.
+
+## Source Documents
+
+Read the foundation in this order:
+
+1. [Product Blueprint](./01-product-blueprint.md)
+2. [Information Architecture](./02-information-architecture.md)
+3. [Creative Direction](./03-creative-direction.md)
+4. [Visual World Exploration](./04-visual-world-exploration.md)
+5. [Homepage Specification](./05-homepage-specification.md)
+6. [Design Principles](./06-design-principles.md)
+7. [Open Questions](./07-open-questions.md)
+
+See [README](./README.md) for the purpose of each document.
+
+## Final Decision Filter
+
+> Does this make the system clearer, the judgment more credible, or the person more memorable?
+
+If the answer is no, remove it—even if the effect is technically impressive.

--- a/docs/design/01-product-blueprint.md
+++ b/docs/design/01-product-blueprint.md
@@ -1,0 +1,293 @@
+# Product Blueprint
+
+> A living systems studio—not a software engineer portfolio.
+
+Product narrative, experience architecture, interaction philosophy, visual language, and creative directions for a portfolio built to support a distinguished engineer, product builder, and future founder.
+
+## The Decisive Creative Position
+
+### Make the ecosystem the portfolio.
+
+The site is not a gallery of things John has made. It is a guided tour through one evolving body of work: intelligent systems that remove friction from everyday life. Jarvis is the orchestrator, AI-Lab is the workshop, and each agent is a specialized capability within the same long-term pursuit.
+
+> **The assumption to challenge**
+>
+> “Engineering workshop” is useful internally, but weak as a literal visual theme. Workbenches, dashboards, dark grids, and glowing nodes are already AI-portfolio shorthand. The memorable idea is not the lab décor—it is watching multiple systems cooperate around a human life.
+
+### Promise
+
+**Everyday life, thoughtfully automated.**
+
+A clear point of view that is larger than a job title and durable enough for future companies.
+
+### Proof
+
+**Connected systems, not isolated demos.**
+
+Show orchestration, trade-offs, outcomes, and evolution—not just polished screenshots.
+
+### Personality
+
+**Precision with warmth.**
+
+Keep pixel-era character as tiny signatures, then add travel, audio, curiosity, and humor.
+
+## The Story
+
+1. **Observe the friction.** Modern life is full of small coordination costs: remembering, planning, deciding, checking, and switching contexts.
+2. **Build a capability.** Each agent begins with one human need, then becomes a reliable specialist rather than a feature demo.
+3. **Connect the system.** Jarvis coordinates context and action, revealing that the value lives between projects as much as inside them.
+4. **Reveal the ambition.** This is an ongoing practice in designing products that make advanced technology feel quietly useful.
+
+## The Emotional Journey
+
+| Stage | Emotion | Visitor response |
+|---|---|---|
+| 01 | Intrigue | This feels unlike a résumé site. |
+| 02 | Orientation | I understand John’s thesis immediately. |
+| 03 | Comprehension | These agents form one connected system. |
+| 04 | Trust | The work shows judgment, architecture, and proof. |
+| 05 | Warmth | There is a human life behind the machinery. |
+| 06 | Invitation | I want to explore, collaborate, or talk. |
+
+## The 10-Second Test
+
+### What the homepage must communicate
+
+**John Moses designs intelligent systems for everyday life.**
+
+He is a Software Engineer at Microsoft. Jarvis coordinates a growing ecosystem of agents for time, travel, health, and daily routines.
+
+### Hero copy direction
+
+**Everyday life, thoughtfully automated.**
+
+John Moses builds connected AI systems that turn daily friction into calm, useful experiences.
+
+Primary paths:
+
+- Explore the system
+- Selected work
+
+## Interaction and Identity
+
+### Delight should reveal intelligence, not decorate it.
+
+Every memorable interaction must perform one of three jobs: explain a relationship, reward curiosity, or reveal John’s point of view. If it does none of those, it is visual debt.
+
+| Interaction | Behavior | Value |
+|---|---|---|
+| Scenario rail | Choose “Start my day,” “Plan a trip,” or “Protect my health.” The ecosystem activates in sequence and explains which agent contributes what. | Signature interaction |
+| Progressive architecture | Begin with the human outcome, then let visitors reveal behavior, decisions, and technical structure one layer at a time. | Clarifies complexity |
+| Relational focus | Hover or keyboard-focus one agent; unrelated nodes recede while dependencies and exchanged context become legible. | Makes the system real |
+| Honest status | Show “active,” “experiment,” or “retired,” plus the latest meaningful change. Avoid invented live telemetry. | Builds trust |
+| Guided Jarvis prompts | Offer three authored demonstrations of orchestration. Do not ship a generic chatbot merely because the project is called Jarvis. | Controlled delight |
+| Optional sound object | A tiny, opt-in audio detail can reveal John’s interest in sound. Never autoplay and never make audio foundational. | Human texture |
+
+## Visual Language
+
+1. **Industrial editorial.** Precision hardware meets an edited field journal: crisp grids, generous margins, fine rules, diagrams, and warm human details.
+2. **Two surface temperatures.** A warm, bright reading surface for trust and a graphite lab surface for system moments. Premium does not require dark-only.
+3. **One signal color.** Use a cool blue or electric cobalt for active intelligence. A restrained amber may indicate caution or human intervention.
+4. **Pixel lineage.** Preserve the old portfolio through 8-bit micro-glyphs, tiny status stamps, or a rare transition artifact—never large pixel scenes.
+
+## Typography and Motion
+
+1. **Humanist grotesk first.** The primary typeface should be modern but not sterile. Use one expressive editorial face only for occasional ideas or quotations.
+2. **Monospace as metadata.** Reserve mono for timestamps, agent states, diagram labels, and system notation. Paragraphs in mono would turn the site into costume.
+3. **Motion follows causality.** If one system triggers another, motion travels in that direction. If detail is revealed, movement should originate from the selected object.
+4. **Calm by default.** Most transitions should finish in 180–360ms. Save one slower sequence for the ecosystem’s defining moment and respect reduced-motion settings.
+
+## Memorable Signatures
+
+### One day, many systems
+
+A six-moment timeline follows one day. Jarvis quietly coordinates briefing, time, travel, reminders, and health. The visitor remembers cooperation—not a card grid.
+
+### Outcome-to-architecture zoom
+
+Every case study can shift between “what it feels like,” “how it decides,” and “how it works.” This becomes a recognizable storytelling grammar.
+
+### The pixel checksum
+
+Each finished system receives a tiny pixel stamp derived from its purpose. It honors the old site and creates collectible visual identity without nostalgia taking over.
+
+## Absolute Exclusions
+
+1. “Hi, I’m John” as the primary idea.
+2. A six-card project grid where every project appears equally important.
+3. Skill bars, logo clouds, contribution graphs, or a giant technology inventory.
+4. Fake terminals, fake system logs, fake live users, or fabricated telemetry.
+5. A free-form AI chatbot with no designed purpose.
+6. Scroll-jacking, mandatory horizontal scroll, or constant parallax.
+7. Custom cursors, autoplay audio, excessive glass blur, or glow on every edge.
+8. Dark mode as a substitute for cinematic art direction.
+9. Microsoft as the story rather than one signal of credibility.
+10. Confidential workplace details or claims that cannot be demonstrated.
+11. Pixel art used as the whole aesthetic instead of a trace of lineage.
+12. Resume chronology before the visitor understands the body of work.
+
+## Three Creative Directions
+
+These are not three skins for the same layout. Each direction changes the storytelling model, interaction density, and audience signal.
+
+### Quiet Intelligence
+
+**Recommended foundation**
+
+#### Philosophy
+
+Intelligence should feel calm, legible, and almost inevitable. The portfolio behaves like a beautifully designed instrument: generous space, precise diagrams, warm surfaces, and a few moments of controlled wonder.
+
+#### Mood board
+
+Morning light on precision hardware · soft paper and anodized metal · museum labels · Arc’s friendliness · Apple’s restraint · Stripe’s explanatory diagrams · one blue indicator waking up
+
+#### Visual references
+
+Apple product storytelling for pacing; Stripe for technical explanation; Arc for charm; Linear for density control; Dieter Rams-era industrial design for restraint.
+
+#### Color palette
+
+Bone `#F4F1EA` · Ink `#151515` · Graphite `#373A3F` · Signal blue `#5B7CFA` · Mineral green `#7A8F82`
+
+#### Typography
+
+ABC Diatype or Neue Montreal for the primary voice; Berkeley Mono for system notation. Accessible fallback: Geist Sans + IBM Plex Mono. Use mono for metadata, never for paragraphs.
+
+#### Animation philosophy
+
+Mostly 180–360ms. Elements clarify relationships rather than announce themselves. Soft fades, masked reveals, and line-tracing; one longer 700ms ecosystem sequence at the signature moment.
+
+#### Strengths
+
+Timeless, readable, premium, and credible to both product and engineering audiences. Gives complex systems enough air. Least likely to age badly.
+
+#### Weaknesses
+
+Restraint can become anonymous if the ecosystem choreography and editorial voice are not distinctive. Requires excellent spacing and typography to avoid looking merely minimal.
+
+#### Who it impresses most
+
+Design-minded engineering leaders, founders, distinguished engineers, product executives, and collaborators who value judgment.
+
+#### Long-term scalability
+
+Excellent. New agents, essays, experiments, and ventures can enter a stable visual grammar without redesigning the site.
+
+### Systems Observatory
+
+**Most cinematic**
+
+#### Philosophy
+
+The visitor enters a dark spatial instrument for observing an evolving constellation of agents. Jarvis is the gravitational center, while every project appears as a live subsystem with visible relationships.
+
+#### Mood board
+
+Dark optical glass · aerospace plotting tables · observatory maps · Linear’s precision · Nothing’s exposed logic · a silent control room before sunrise
+
+#### Visual references
+
+Nothing for exposed structure; Linear for precision; Vercel for contrast; scientific visualization; restrained fictional R&D interfaces without franchise cues.
+
+#### Color palette
+
+Void `#0D0F12` · Steel `#22262C` · Fog `#C8CDD4` · Ion blue `#76A9FA` · Caution amber `#E7A94B`
+
+#### Typography
+
+PP Neue Montreal or Suisse Intl for interface text; JetBrains Mono for coordinates and system labels. Tight display tracking, highly readable body copy.
+
+#### Animation philosophy
+
+Camera-like depth and purposeful sequencing, 240–600ms. Nodes wake as context flows between them. No floating particles, infinite ambient loops, or mouse-chasing effects.
+
+#### Strengths
+
+Immediate impact, a strong workshop/lab metaphor, and a natural home for ecosystem visualization. Most likely to produce a memorable first impression.
+
+#### Weaknesses
+
+Highest risk of becoming the exact “futuristic engineer portfolio” cliché to avoid. Dark, spatial UI also costs more to build, maintain, and make accessible.
+
+#### Who it impresses most
+
+AI builders, technical recruiters, innovation teams, developer-tool founders, and visitors who reward spectacle.
+
+#### Long-term scalability
+
+Good for the ecosystem, weaker for long-form writing and future company-building unless paired with a calmer editorial layer.
+
+### The Human Systems Journal
+
+**Most personal**
+
+#### Philosophy
+
+Treat the portfolio as an edited field journal about reducing friction in ordinary life. Projects appear as observations, system sketches, decisions, and outcomes—not product tiles.
+
+#### Mood board
+
+Architect’s notebook · premium travel journal · warm editorial paper · technical annotations · product sketches · tiny pixel stamps inherited from an earlier era
+
+#### Visual references
+
+Independent design magazines; Braun manuals; travel ephemera; high-quality annual reports; Stripe Press; editorial case studies with restrained technical notation.
+
+#### Color palette
+
+Paper `#F0EAE0` · Carbon `#20201F` · Rust `#B45B3E` · Moss `#67735B` · Cobalt `#315E9A`
+
+#### Typography
+
+Newsreader or Tiempos for selective editorial moments; Neue Haas Grotesk or Inter for structure; IBM Plex Mono for annotations. Serif is seasoning, not the interface.
+
+#### Animation philosophy
+
+Editorial transitions: annotations arrive, diagrams assemble, marginalia reveals on intent. 160–300ms with almost no depth or parallax.
+
+#### Strengths
+
+Most differentiated from AI-portfolio clichés and best at revealing taste, curiosity, travel, audio, and product judgment. Preserves personality naturally.
+
+#### Weaknesses
+
+Can understate technical ambition if diagrams and evidence are too soft. Risks feeling like a design portfolio unless system depth is explicit.
+
+#### Who it impresses most
+
+Founders, product designers, creative technologists, editorial-minded leaders, and people who may want to build a company with John.
+
+#### Long-term scalability
+
+Excellent for essays, research, and a future founder narrative. The ecosystem needs a clear recurring diagram so it does not fragment into stories.
+
+## Creative Decision
+
+### Build Quiet Intelligence, then borrow personality—not structure—from the Journal.
+
+Use Quiet Intelligence as the durable product system. Bring in the Human Systems Journal’s warmth, annotations, and pixel checksum. Reserve Systems Observatory for one bounded ecosystem sequence rather than making the entire website a control room.
+
+- **70% Quiet Intelligence:** Layout, type, pacing, hierarchy, and overall restraint.
+- **20% Human Systems Journal:** Voice, annotations, warmth, artifacts, and pixel lineage.
+- **10% Systems Observatory:** The signature ecosystem map and orchestration sequence only.
+
+### The North-Star Experience
+
+A visitor lands on a calm, confident statement. A subtle system map wakes. They select “Plan a trip.” Jarvis gathers calendar context, Flight Agent evaluates movement, Reminder Agent closes a loop, and the interface explains the handoffs. In under a minute, the visitor understands both the product vision and John’s engineering judgment.
+
+## Design Principles
+
+1. **Human outcome before technical mechanism.** Lead with the life improved; earn the right to reveal architecture.
+2. **Relationships before inventory.** The connections between systems communicate more ambition than the number of projects.
+3. **Evidence before adjectives.** Demonstrate reliability, constraints, decisions, and iteration instead of repeatedly saying “intelligent” or “innovative.”
+4. **One moment of magic.** Concentrate cinematic craft in the ecosystem scenario; keep the rest calm and fast.
+5. **A person, not a persona.** Microsoft is context. Interests create warmth. The work and point of view remain the center.
+
+## Related Documents
+
+- [Information Architecture](./02-information-architecture.md)
+- [Creative Direction](./03-creative-direction.md)
+- [Design Principles](./06-design-principles.md)
+- [Open Questions](./07-open-questions.md)

--- a/docs/design/02-information-architecture.md
+++ b/docs/design/02-information-architecture.md
@@ -1,0 +1,183 @@
+# Information Architecture
+
+## Organize by Role in the System, Then by Human Outcome
+
+Do not present eight equal “projects.” That framing makes the work look smaller and more fragmented than it is.
+
+The primary object is AI-Lab. Jarvis is its coordinating interface. The agents are capabilities grouped around needs.
+
+## AI-Lab Ecosystem
+
+```mermaid
+flowchart TD
+    Intent["Human intent"] --> Jarvis["Jarvis<br/>Understands intent<br/>Coordinates specialists<br/>Preserves context<br/>Presents one coherent experience"]
+
+    Jarvis --> Daily["Daily Intelligence"]
+    Jarvis --> Time["Time"]
+    Jarvis --> Movement["Movement"]
+    Jarvis --> Wellbeing["Wellbeing"]
+
+    Daily --> Morning["Morning Briefing Agent<br/>Anticipates"]
+    Time --> Calendar["Calendar Agent<br/>Coordinates"]
+    Time --> Reminder["Reminder Agent<br/>Remembers"]
+    Movement --> Flight["Flight Agent<br/>Navigates"]
+    Wellbeing --> Nutrition["Nutrition Agent<br/>Guides"]
+    Wellbeing --> Health["Health Agent<br/>Understands"]
+
+    Foundation["Shared context · Memory · Trust · Automation boundaries · Design principles"] --- Jarvis
+```
+
+### Orchestration Layer
+
+**Jarvis**
+
+Understands intent · coordinates specialists · preserves context · presents one coherent experience
+
+### Capabilities
+
+| Capability | Role | Purpose |
+|---|---|---|
+| Morning Briefing | Anticipates | Turns context into a useful start to the day. |
+| Flight Agent | Navigates | Reduces uncertainty around movement and travel. |
+| Calendar Agent | Coordinates | Protects time and resolves scheduling friction. |
+| Reminder Agent | Remembers | Closes loops before they become cognitive load. |
+| Nutrition Agent | Guides | Makes everyday food decisions more informed. |
+| Health Agent | Understands | Finds useful patterns across personal wellbeing. |
+
+Shared context, memory, trust, automation boundaries, and design principles live beneath every capability.
+
+## Homepage Sequence
+
+1. **Threshold.** A decisive thesis, one-line identity, and an ecosystem glimpse. No biography dump.
+2. **The system.** An explorable map showing Jarvis coordinating specialized agents inside AI-Lab.
+3. **A day with the system.** One guided scenario demonstrates collaboration better than six isolated cards.
+4. **Jarvis.** The flagship case study: intent, orchestration, decisions, evolution, and limits.
+5. **Selected systems.** Three to four deeper stories organized by human need, not technology.
+6. **Lab notes.** Architecture decisions, experiments, failures, and product thinking in compact form.
+7. **The builder.** A concise human portrait: Microsoft, principles, interests, and the life motivating the work.
+8. **Open channel.** A restrained invitation to discuss systems, products, research, or ambitious ideas.
+
+The shipping homepage sequence refines this architecture into seven narrative phases. See [Homepage Specification](./05-homepage-specification.md).
+
+## Project Hierarchy
+
+### A. Flagship system
+
+Jarvis receives the richest story and demonstrates orchestration across the whole ecosystem.
+
+### B. Capability stories
+
+Group agents under Time, Movement, Wellbeing, and Daily Intelligence. Feature only the strongest three or four.
+
+### C. Experiments
+
+Smaller tools belong in a compact lab index with honest status, a sharp premise, and one learning.
+
+### D. Foundations
+
+Architecture, memory, evaluation, privacy, and automation principles appear as reusable system layers—not separate portfolio projects.
+
+## Case-Study Anatomy
+
+1. **Human friction.** What recurring problem was worth removing?
+2. **System behavior.** What does the experience do from the user’s point of view?
+3. **Judgment.** Which constraints, risks, and trade-offs shaped it?
+4. **Architecture.** How do data, intelligence, interfaces, and automation cooperate?
+5. **Evidence.** What works, what changed, and what can be demonstrated honestly?
+6. **Next frontier.** How does this capability strengthen the larger ecosystem?
+
+## Jarvis Positioning
+
+### Jarvis should be central, not oversized.
+
+Jarvis becomes important through relationships: other agents route through it, scenarios begin with it, and every case study returns to the shared system.
+
+Avoid:
+
+- A giant Jarvis logo.
+- A product-pricing narrative.
+- Repeated “assistant” claims.
+- A face, glowing orb, voice waveform, or superhero mythology.
+- A floating assistant, conversational overlay, mascot, or replacement for clear navigation.
+
+The system map does the positioning work.
+
+## Outcome-Based Entry Points
+
+Visitors choose a human intention rather than selecting an agent:
+
+- Start my day.
+- Plan travel.
+- Protect my time.
+- Understand my health.
+
+Only relationships relevant to the chosen intention gain emphasis. Unrelated systems recede but remain spatially present.
+
+## Capability States
+
+Use precise, humane states:
+
+- In daily use.
+- On the bench.
+- Under test.
+- Retired with lessons.
+
+Do not invent live telemetry. Show the latest meaningful change instead.
+
+## Evidence Architecture
+
+Artifacts are assembled, not carded. Each story begins with one primary piece of real work. Supporting evidence sits in a deliberate relationship around it.
+
+### Evidence types
+
+| Type | Question | Form |
+|---|---|---|
+| Output | What did the system produce? | Screenshot, briefing, recommendation, reminder, itinerary, or report. |
+| Decision | Why does it behave this way? | A consequential choice with context, alternatives, and outcome. |
+| Tradeoff | What was protected? | Speed versus trust, automation versus confirmation, breadth versus reliability. |
+| Change | How did the work evolve? | A dated revision, deployment note, or meaningful commit explained in human terms. |
+| Failure | What did not survive? | A rejected experiment and the evidence that ended it. |
+| Boundary | Where does the system stop? | Privacy, uncertainty, maintenance, or a decision deliberately left to a person. |
+
+### Three-depth lens
+
+Each artifact can be read at three depths:
+
+1. Experience
+2. Decisions
+3. Architecture
+
+The artifact remains in position while its annotation layer changes.
+
+## Navigation Model
+
+Navigation behaves like a datum rail, not a themed control panel.
+
+```text
+JOHN MOSES                    SYSTEM    EVIDENCE    NOTES    CONTACT
+──────────────────────────────────────────────────────────────────
+```
+
+### Primary destinations
+
+- **System:** Returns to the AI-Lab ecosystem and authored scenarios.
+- **Evidence:** Moves to the first artifact assembly, not a project listing.
+- **Notes:** Opens lab notes, decisions, experiments, and field observations.
+- **Contact:** Moves to the Far End and its direct invitation.
+
+### Secondary orientation
+
+- **Workbench index:** A compact index lists capabilities, artifacts, notes, and states for visitors who prefer direct lookup.
+- **Current context:** Inside the instrument, a small label states the active intention and participating systems.
+- **Return path:** Every deep artifact links back to its role in the ecosystem.
+- **Professional references:** GitHub, LinkedIn, and résumé remain compact at the Far End.
+
+### Usability boundary
+
+The Long Table metaphor governs composition and storytelling. It does not rename familiar actions, conceal destinations, require horizontal travel, or make visitors manipulate objects to access essential content.
+
+## Related Documents
+
+- [Product Blueprint](./01-product-blueprint.md)
+- [Homepage Specification](./05-homepage-specification.md)
+- [Design Principles](./06-design-principles.md)

--- a/docs/design/03-creative-direction.md
+++ b/docs/design/03-creative-direction.md
@@ -1,0 +1,315 @@
+# The Luminous Workshop
+
+> A visual identity for Quiet Intelligence: warm bench, precise instrument, causal motion, authored artifacts, and one unmistakable human hand.
+
+## 1. Atmosphere
+
+### Imagine a drafting table after everyone else has left.
+
+Warm paper catches a quiet pool of museum light. Beside it, anodized aluminum absorbs the room rather than reflecting it. A smoked-glass instrument is recessed into the table—dark, exact, and dormant until needed. Fine graphite marks show that someone has been thinking here. Nothing begs to be touched, yet every object feels considered.
+
+This is not a spaceship cockpit. It is not a laboratory set. It is the private working environment of a person who makes advanced systems feel calm enough to live with.
+
+### The Sensory Brief
+
+| Sense | Direction |
+|---|---|
+| Temperature | Warm room, cool instrument. |
+| Sound | The soft click of a precise control; otherwise silence. |
+| Touch | Uncoated paper, bead-blasted metal, one pane of optical glass. |
+| Pace | A confident host who never rushes the visitor. |
+
+### The Environment Has Four Layers
+
+#### Bench
+
+Warm, matte, editorial. This is where ideas, explanations, and personal artifacts live. It feels touched and inhabited.
+
+#### Instrument
+
+Dark, recessed, exact. This is where systems become active and relationships are observed. It feels engineered, not decorated.
+
+#### Signal
+
+Cobalt for intelligence in motion; workshop amber for uncertainty or human intervention. Signal color is an event, never atmosphere.
+
+#### Artifact
+
+Notes, diagrams, recordings, stamps, and imperfect evidence. This layer carries John’s hand and prevents minimalism from becoming anonymous.
+
+## 2. Lighting
+
+1. **Museum light, not screen glow.** Objects feel illuminated from the environment. The page does not appear to emit white light from every surface.
+2. **One brightest idea per view.** The eye should always know what the room is presenting. Secondary surfaces step back by value, not blur.
+3. **Light reveals state.** A dormant instrument is charcoal and quiet. Activation raises local contrast only around the responsible path.
+4. **No theatrical darkness.** Near-black appears in bounded instrument wells. Reading surfaces remain warm and generous.
+
+## 3. Rhythm and Density
+
+1. **Rooms, not stripes.** Each major section should feel like entering a distinct work area with its own scale and purpose.
+2. **Sparse → precise → silent.** Open with space, build to relational density, then provide a full visual exhale.
+3. **Museum distance.** An object and its label remain intimate; unrelated objects receive enough space to become separate thoughts.
+4. **One dense room at a time.** Never place architecture, motion, personal imagery, and long copy in the same visual field.
+
+> **Pushback: restraint alone will not make this John’s**
+>
+> The canonical direction is elegant but one decision away from becoming a very good minimalist technology site. Apple-like whitespace is not identity. The risk worth taking is environmental: commit to the physical tension between warm bench and dark instrument, then let authored artifacts interrupt the perfection.
+
+## 4. The First 60 Seconds
+
+The first minute is an arrival, a demonstration, and a human introduction.
+
+The page earns attention in waves. It never begins with spectacle. Stillness establishes confidence; causality creates wonder; silence gives meaning; evidence creates trust.
+
+| Time | Moment | Experience | Feeling |
+|---|---|---|---|
+| 0–2 seconds | Arrival | A field of warm, mineral paper fills the screen. In one quiet corner: JOHN MOSES / SOFTWARE ENGINEER / SYSTEMS BUILDER. The main sentence is already present—no theatrical loading, no logo ceremony. Almost everything is still. | Composure |
+| 2–6 seconds | Recognition | Beside the statement sits a dark, recessed instrument aperture. It looks less like a card and more like a precision device set into a drafting table. Inside: a dormant arrangement of labels and fine lines. One cobalt registration point confirms that it is awake. | Intrigue |
+| 6–12 seconds | First life | As attention reaches the aperture, Jarvis resolves from annotation into coordinating presence. Not an orb, face, or logo. A line leaves it, travels with purpose, and wakes two specialist systems. Their labels become legible only after the relationship exists. | Intelligence |
+| 12–22 seconds | The thesis becomes visible | The visitor understands that the page is not showing projects. It is showing one environment. The headline remains anchored while the system map exposes Time, Movement, Wellbeing, and Daily Intelligence as connected regions. | Orientation |
+| 22–34 seconds | The first wonder | A single invitation appears: PLAN A TRIP. When chosen, Jarvis consults Calendar, wakes Flight, and leaves Reminder with a future obligation. Each handoff is visible, ordered, and briefly explained. The sequence feels authored—not simulated. | Wonder |
+| 34–42 seconds | Silence | The traces cool. The instrument stops moving. A broad field of space follows with one sentence: The most useful intelligence is often the least visible. Nothing asks for attention for several beats. | Reflection |
+| 42–51 seconds | Evidence on the bench | Selected systems appear as working artifacts: a decision, a real output, a constraint, and a status. They are not glossy product cards. They resemble labeled specimens laid out for inspection, each with enough asymmetry to feel handled. | Trust |
+| 51–60 seconds | The person enters | A non-AI artifact interrupts the systems story: a field recording, a travel observation, or a product sketch with a short note in John’s voice. The environment gains a maker. At sixty seconds, the visitor knows the ambition and wants to know the person. | Warmth |
+
+### What Stays Still
+
+The identity, thesis, and reading surface do not drift, float, or react to the cursor. Personal artifacts hold their position like real objects. The system waits until the visitor expresses intent. Stability makes intelligence feel trustworthy.
+
+### What Feels Alive
+
+Relationships, responsibility, and state. A connector appears only when context moves. A label sharpens only when its system matters. The environment is alive because it responds correctly—not because it is constantly moving.
+
+### Why They Keep Scrolling
+
+The visitor has seen one capability wake but not yet seen the full consequence. A partially revealed annotation at the lower edge points toward the next room. Curiosity comes from an unfinished idea, not a bouncing arrow or “scroll to explore” instruction.
+
+## 5. Visual Language
+
+### The visual grammar is called Bench / Instrument.
+
+Every page is composed from a warm working surface and, when the story requires behavior, a dark precision instrument. The tension between them is the identity. One feels physical and accumulated; the other feels digital and exact.
+
+### Material Palette
+
+1. **Drafting paper.** Ivory with a grey-green undertone—never cream, never luxury beige. It should feel archival, intelligent, and easy on the eyes.
+2. **Carbon ink.** A soft near-black with a trace of warmth. Pure black is reserved for optical depth inside an instrument.
+3. **Anodized aluminum.** Neutral mid-grey used for frames, labels, dividers, and controls. Matte and bead-blasted, not chrome.
+4. **Smoked optical glass.** A bounded dark plane for systems. Crisp enough for diagrams; deep enough to feel inset into the bench.
+5. **Cobalt signal.** A dense mineral blue, closer to engineer’s marking ink than electric neon. It means context is moving or a decision is active.
+6. **Workshop amber.** Rare and slightly dusty. It marks ambiguity, human approval, or a boundary—not generic warning.
+
+### Shape Vocabulary
+
+1. **The workplate.** A calm rectangular field with softened, machined corners. Used for artifacts and explanations; never made to float.
+2. **The aperture.** A wider, darker inset whose edge feels engineered. It is the recurring home of system behavior.
+3. **The calibration notch.** A tiny square interruption cut into labels, dividers, and stamps. It is the mature descendant of the pixel aesthetic.
+4. **The ledger line.** Hairline rules create alignment and provenance. Thick outlines are reserved for deliberate selection, never default containment.
+5. **The checksum.** An 8×8 pixel mark used at endings and ownership points. It is a signature, not an illustration.
+6. **The agent marker.** A precise label with state—not a glowing sphere, mascot, avatar, or app icon.
+
+### The Composition Contract
+
+1. **Asymmetry must explain importance.** The larger field carries the thesis; smaller adjacent artifacts provide evidence or annotation.
+2. **One active plane per viewport.** Only one surface may behave like an instrument at a time.
+3. **Labels remain tethered.** Metadata belongs to an object edge or ledger line. Nothing floats as decorative UI.
+4. **Copy and signal never cross.** Body text must never sit inside moving diagrams or under connector lines.
+5. **Corners reveal material.** Paper corners are restrained; instrument corners feel machined. Avoid pill shapes except true state controls.
+6. **Depth comes from occlusion.** Use overlap, value, and framing. Heavy shadows and blurred glass make the environment feel synthetic.
+7. **Color follows responsibility.** Cobalt means active intelligence; amber means human judgment. Neither is decorative.
+8. **Every room contains a trace of use.** A note, timestamp, revision, checksum, or imperfection keeps the place inhabited.
+
+## 6. Typography Philosophy
+
+The primary voice is a humanist grotesk: precise enough for an instrument, warm enough for a personal sentence. It should have quiet character in the lowercase and excellent numerals. ABC Diatype, Söhne, or Neue Montreal are the right territory.
+
+A disciplined monospace—Berkeley Mono or IBM Plex Mono—belongs only to state, time, coordinates, system names, and short annotations. It is the sound of the instrument, not John’s speaking voice.
+
+If an editorial serif appears, it does so once per long page: a reflective sentence, field note, or human observation. It must never become the luxury layer.
+
+### Spacing and Type Behavior
+
+- **Sentence case carries confidence.** Avoid interface shouting. Uppercase belongs to tiny engraved labels only.
+- **Short lines feel authored.** Body copy should read like a museum caption or thoughtful field note, not a marketing column.
+- **Numbers become architecture.** Use tabular numerals for time, states, versions, and sequences; they create rhythm without ornament.
+- **Headlines make claims, not introductions.** No oversized name, generic greeting, or stack of vague adjectives.
+
+## 7. Motion Philosophy
+
+### Motion is the visible transfer of responsibility.
+
+Nothing “comes alive” on its own. Motion begins with intent, travels through a relationship, changes a state, and settles. The visitor should be able to explain why every moving thing moved.
+
+### Timing Tiers
+
+| Duration | Tier | Purpose |
+|---|---|---|
+| 90–140ms | Contact | Press, focus, selection, and tiny state acknowledgment. Immediate; never bouncy. |
+| 180–260ms | Interface | Labels, panels, filters, and local reveals. Fast departure, soft landing. |
+| 320–480ms | Relationship | A dependency becomes visible or one agent activates another. Enough time to read causality. |
+| 700–1100ms | Narrative | Reserved for the one orchestration sequence or a major change of environment. Used once, not everywhere. |
+
+### Causal Choreography
+
+When one system activates another:
+
+1. **Intent.** The initiating object acknowledges the visitor with a brief compression or contrast change.
+2. **Commit.** A small registration mark locks in, showing that the request has become system work.
+3. **Transfer.** A line draws from source to receiver at constant visual speed. Direction is unmistakable.
+4. **Response.** The receiving label sharpens, then its local evidence appears. It never activates before the signal arrives.
+5. **Settle.** The connector fades to a structural trace while the resulting state remains. History is quieter than action.
+
+### Acceleration and Easing
+
+1. **Controls are decisive.** Fast departure, short travel, firm landing. No elastic overshoot and no playful bounce in system behavior.
+2. **Signals travel evenly.** A transfer line should feel measured, not theatrical. Constant visual velocity makes causality readable.
+3. **Objects arrive softly.** Revealed information decelerates into position as if placed by hand, not launched by software.
+4. **Parallel work looks parallel.** Only genuinely simultaneous systems may activate together; sequence is the visual grammar of dependency.
+
+### Interaction Language
+
+1. **Focus reveals relevance.** Hover and keyboard focus clarify related objects while unrelated information recedes slightly.
+2. **Selection changes the room.** A chosen scenario persists until dismissed. The environment should not reset because the pointer moved away.
+3. **Exploration is layered.** The first interaction reveals behavior; a second may reveal a decision; architecture remains an intentional deeper step.
+4. **The cursor stays ordinary.** Craft belongs to the environment and response—not a custom pointer chasing the visitor.
+
+### The Motion Rule
+
+> Initiator first. Relationship second. Receiver third. Consequence last.
+
+If the order is different, the system will look magical instead of intelligent.
+
+## 8. Signature Moments
+
+A signature moment is not an effect. It is a point where the visual identity, product thesis, and John’s character become inseparable.
+
+### 01. The Jarvis Handoff
+
+**Jarvis · intelligence**
+
+The visitor chooses a human intention, not an agent. Jarvis decomposes it into a small chain of responsibilities. Calendar contributes context; Flight resolves uncertainty; Reminder accepts a future obligation. The system explains itself through action.
+
+**What remains weeks later:** They remember that the portfolio made orchestration understandable without a diagram lecture.
+
+**The restraint that protects it:** Three authored scenarios only. No open-ended chatbot, fake thinking text, or decorative pulse.
+
+### 02. The Listening Shelf
+
+**No AI · personality**
+
+A narrow shelf holds one field recording from travel, one favorite piece of audio hardware, and one brief observation about designed sound. Selecting an object reveals a precise note and, only by request, a few seconds of audio.
+
+**What remains weeks later:** They remember entering a real person’s workshop, not an AI brand environment.
+
+**The restraint that protects it:** No autoplay, lifestyle feed, or mood-board collage. Three objects are stronger than thirty.
+
+### 03. The Decision Ledger
+
+**Judgment · craftsmanship**
+
+Every major system includes one visible decision that prevented complexity: what John deliberately refused to automate, what failed, or where human confirmation remains essential.
+
+**What remains weeks later:** They remember a builder confident enough to show boundaries, not merely capabilities.
+
+**The restraint that protects it:** Use real decisions with dates and consequences. Never manufacture process theater.
+
+### 04. The Three-Depth Lens
+
+**Systems thinking**
+
+The same artifact can be read at three depths: Experience, Decisions, Architecture. The composition does not change pages; its annotation layer changes. A human outcome slowly reveals the system beneath it.
+
+**What remains weeks later:** They remember being able to move from product feeling to engineering depth without losing context.
+
+**The restraint that protects it:** The lens must preserve position and hierarchy. It is not three tabs containing unrelated content.
+
+### 05. The Pixel Checksum
+
+**Lineage · authorship**
+
+Every completed system earns a tiny 8×8 mark generated from a human-authored pattern vocabulary. At first it reads as a registration stamp. Visitors who inspect it discover a quiet link to the portfolio that came before.
+
+**What remains weeks later:** They remember a mature site that did not erase its younger, more playful self.
+
+**The restraint that protects it:** Never enlarge it into decoration. It belongs in corners, captions, loading states, and signatures.
+
+## 9. Where to Take a Bigger Risk
+
+1. **Remove the conventional project grid.** Let the one-day scenario become the homepage’s primary navigation into work. This is a structural risk with real payoff.
+2. **Show an unfinished edge.** A visible decision ledger and honest project states are more distinctive than another polished mockup.
+3. **Cross the environmental threshold.** Allow one clear transition from warm bench into dark instrument. Do not dilute it into alternating light and dark stripes.
+4. **Include one personal sensory artifact.** A field recording or travel observation adds more authorship than a louder hero animation.
+
+## 10. Where Not to Take the Risk
+
+1. **Not in legibility.** Typography, contrast, navigation, and reduced motion remain exceptionally conventional.
+2. **Not in fake intelligence.** The system may be authored and demonstrative; it must never imply real-time agency it does not have.
+3. **Not in visual noise.** The environment earns distinction through material contrast and behavior, not more particles, glows, and layers.
+4. **Not in fan-service.** Jarvis is a system role, not a Marvel reference. Remove every cue that depends on borrowed mythology.
+
+## 11. Hidden Details
+
+1. **Bench status.** Use precise, humane states: On the bench, In daily use, Under test, Retired with lessons.
+2. **Old-world portal.** One pixel checksum can open an archived glimpse of the previous portfolio—clearly labeled as history, never mixed into the current navigation.
+3. **Time stamp.** Lab notes carry the date of the last meaningful decision, not a fake “live” indicator.
+4. **Travel coordinates.** A few personal artifacts may carry coordinates or local time as quiet metadata, never as map decoration.
+5. **Sound etiquette.** The audio control remembers silence. It never assumes consent and never competes with reading.
+6. **404 drawer.** A missing page becomes a mislabeled workshop drawer: brief, dry, useful, and immediately navigable.
+7. **Reduced-motion craft.** Motion-reduced mode replaces travel with state changes and line emphasis; it should feel designed, not disabled.
+8. **Microcopy signature.** Use John’s direct voice in small places: what changed, what surprised me, what I would not automate.
+
+### The Personality Test
+
+Remove John’s name and project titles. If the site could plausibly belong to any thoughtful AI engineer, it is not finished.
+
+The pixel checksum, decision ledger, listening shelf, travel metadata, and direct microcopy must form a recognizable fingerprint.
+
+## 12. Things We Must Never Do
+
+1. Never personify Jarvis with a face, glowing orb, voice waveform, or superhero mythology.
+2. Never illuminate every edge. Light indicates attention or transferred responsibility.
+3. Never place body copy over an active system visualization.
+4. Never let a connector cross text, another connector, or an unrelated object.
+5. Never make every section full-screen; cinematic scale without intimacy becomes monotonous.
+6. Never use glass blur as the default material. Glass is an aperture, not wallpaper.
+7. Never animate because the page is idle. A living system is responsive, not restless.
+8. Never use a technology logo as visual proof of engineering depth.
+9. Never let Microsoft’s brand colors, language, or prestige determine John’s identity.
+10. Never use “futuristic” as permission for illegible contrast, tiny type, or ambiguous controls.
+11. Never flatten experiments and mature systems into the same level of finish.
+12. Never add an effect that cannot explain what caused it.
+
+## 13. Why It Can Still Feel Modern in 2035
+
+1. **It is based on materials, not trends.** Paper, metal, glass, ink, and light are durable references. They predate today’s interface fashion and will outlast it.
+2. **Behavior has semantics.** Motion represents intent, transfer, response, and consequence. Meaningful motion ages better than fashionable transitions.
+3. **The identity can absorb new eras.** AI-Lab may gain agents, products, research, or companies without changing the Bench / Instrument grammar.
+4. **Evidence replaces hype.** Decisions, limits, and outcomes remain credible even when today’s AI language becomes dated.
+5. **History is allowed to remain visible.** The checksum and archive turn previous aesthetics into lineage rather than embarrassment.
+
+### The 2035 Aging Test
+
+#### Remove the current technology nouns
+
+The site should still describe a person who observes human friction, builds thoughtful systems, and connects specialized capabilities into coherent products.
+
+#### Replace every project
+
+The visual language should still hold. New ventures become artifacts on the bench; new behaviors enter the instrument; new decisions join the ledger.
+
+#### Turn all motion off
+
+The composition, writing, hierarchy, and material contrast must remain distinctive. Motion deepens the identity; it cannot be the identity.
+
+## Creative North Star
+
+> A quiet room. A precise instrument. Evidence of a curious person at work.
+
+The future is present, but it has been made calm enough to examine.
+
+## Related Documents
+
+- [Product Blueprint](./01-product-blueprint.md)
+- [Visual World Exploration](./04-visual-world-exploration.md)
+- [Homepage Specification](./05-homepage-specification.md)
+- [Design Principles](./06-design-principles.md)

--- a/docs/design/04-visual-world-exploration.md
+++ b/docs/design/04-visual-world-exploration.md
@@ -1,0 +1,480 @@
+# Six Homepage Visual Worlds
+
+Six physical places, six camera logics, six material systems, and six interpretations of the same locked promise:
+
+> A quiet room. A precise instrument. Evidence of a curious person at work.
+
+This document preserves the visual-world exploration that led to the canonical selection of **The Long Table**.
+
+## 1. The Long Table
+
+> It feels like walking beside one uninterrupted workbench where a decade of intelligent systems is being assembled in plain sight.
+
+**Distinction:** A continuous place rather than a sequence of page sections. The workbench itself becomes John’s recognizable visual property.
+
+| Coordinate | Direction |
+|---|---|
+| Perspective | Oblique architectural view |
+| Dominant object | A twelve-foot workbench |
+| Light | High north-window daylight |
+
+### First Impression
+
+1. A nearly empty room opens around a long table of pale ash. The visitor sees it from a slightly elevated three-quarter angle, as if they have just stepped through the studio door. The table begins close enough to feel tactile, then recedes into a quiet white distance.
+2. A sheet of heavy drafting stock lies near the front edge. The sentence “Everyday life, thoughtfully automated.” is printed with the confidence of an exhibition title—not centered, not oversized, simply placed where a maker would begin.
+3. Further down the table, a single smoked-glass instrument is inset flush with the wood. It is the darkest object in the room. Around it: a graphite pencil, one translucent overlay, a machined aluminum rail, and an 8×8 checksum stamp. The rest is air.
+4. Nothing floats. Nothing glows. A cobalt line is visible beneath the vellum, then disappears under the glass. That incomplete path creates the first question.
+
+### Hero
+
+- **The headline:** The headline belongs to a physical sheet placed in the near-left foreground. John’s name is engraved on the thin aluminum datum rail running along the table edge.
+- **The dominant object:** The smoked-glass instrument bay dominates by contrast, not size. Jarvis is visible inside it as a precisely labeled coordinating point surrounded by mostly dormant relationships.
+- **The composition:** The front third is intimate and editorial; the middle third contains the instrument; the far third fades into possibility. Negative space is the room itself, not empty margin around cards.
+- **The curiosity engine:** A context line passes under a translucent sheet and vanishes into the instrument. The visitor can see that the bench continues beyond the first screen, but not yet what is being built there.
+
+### Rooms
+
+| Room | Arrival | Purpose |
+|---|---|---|
+| The Threshold | The visitor arrives at the near edge of the table. | Identity, thesis, and one personal note establish who works here. |
+| The Instrument Bay | The camera settles beside the recessed glass. | Jarvis and the ecosystem reveal their relationships through one authored scenario. |
+| The Assembly Area | Loose artifacts become more numerous but remain ordered. | Selected systems appear as evidence: output, decision, constraint, status. |
+| The Decision Bench | The table narrows and the light becomes more directional. | Open ledgers show failed approaches, boundaries, and what remains human. |
+| The Listening Corner | Wood and felt interrupt paper and glass. | A field recording and one audio object reveal John beyond AI. |
+| The Far Cabinet | The table ends at a small archive built into the wall. | Lab notes, retired systems, the old pixel portfolio, and an invitation to continue the conversation. |
+
+### Signature Interaction: The Causal Assembly
+
+The visitor places an intention card—“Plan a trip”—against the instrument rail. Jarvis acknowledges it. A line travels beneath the glass to Calendar, then Flight, then Reminder. Each specialist leaves a small physical result on the adjacent bench: context, decision, obligation.
+
+**What it reveals:** The system is understood as coordinated work that produces human artifacts, not as abstract glowing nodes.
+
+### Materials
+
+- **Pale ash:** Open grain, matte finish, warm without feeling rustic.
+- **Smoked optical glass:** Flush-mounted, dark enough to hold depth, never blurred.
+- **Anodized aluminum:** A thin datum rail, labels, and registration hardware.
+- **Drafting vellum:** Semi-opaque layers carrying alternatives and dependencies.
+- **Cotton rag paper:** Thick enough to feel placed, annotated, and kept.
+- **Graphite and cobalt ink:** Graphite records thought; cobalt records active responsibility.
+
+### Motion
+
+- **The camera accompanies:** Scroll feels like a restrained dolly along the table, not a free-flying 3D tour.
+- **Objects stay weighted:** Paper, tools, and artifacts never float or chase the pointer.
+- **Signals pass beneath surfaces:** Causality travels through the instrument and emerges as a result on the bench.
+- **Rooms settle before changing:** Each working area holds still long enough to inspect before the next comes into view.
+
+### Creative Risk
+
+The entire website commits to one spatial metaphor. The page is no longer a stack of content; it is a place with a front edge, distance, and accumulated evidence.
+
+### Failure Mode
+
+Poor execution becomes a 3D novelty, a heavy scroll experience, or a photorealistic furniture ad. It requires severe discipline: mostly still compositions, excellent art direction, and a complete linear reading mode.
+
+### Long-Term Ceiling
+
+Highest. The table can become an ownable stage for every future project, company, essay, and artifact without changing the identity.
+
+## 2. The Binding Room
+
+> It feels like opening the only surviving field atlas from a research practice that has been quietly documenting the future.
+
+**Distinction:** A monumental editorial object. Knowledge accumulates through layers, folios, transparent overlays, and evidence of revision.
+
+| Coordinate | Direction |
+|---|---|
+| Perspective | Top-down editorial plane |
+| Dominant object | An oversized field atlas |
+| Light | Focused reading-room lamp |
+
+### First Impression
+
+1. A dark, acoustically quiet reading room surrounds one enormous book resting on a low blackened-steel lectern. The camera looks down from standing height. The book is open, but the room around it remains almost entirely unoccupied.
+2. The left page is uncoated ivory stock with a short, exact statement and John’s name in the lower margin. The right page is translucent vellum. Beneath it, fragments of the AI-Lab ecosystem are visible but do not yet align.
+3. A narrow strip of cobalt binding thread appears at the center fold. Tiny brass registration corners hold the vellum in place. One graphite correction has been left visible. This is a living document, not a sacred artifact.
+4. The scale is unusual: the visitor feels small enough to inspect and large enough to turn the thinking over in their hands.
+
+### Hero
+
+- **The headline:** The headline is typeset on the left page like the opening sentence of an atlas, with generous outer margins and a small field-note annotation in John’s voice.
+- **The dominant object:** The atlas dominates everything. The ecosystem is not a graphic beside the hero; it is embedded across layered pages in the book itself.
+- **The composition:** One formal spread, asymmetrical by content: language on the left, latent system on the right, dark room beyond all four page edges.
+- **The curiosity engine:** The vellum’s fragments suggest that lifting or aligning the layer will make separate agent marks become one coherent system.
+
+### Rooms
+
+| Room | Arrival | Purpose |
+|---|---|---|
+| The Title Leaf | A nearly empty opening spread. | Identity and thesis feel authored rather than marketed. |
+| The Legend | A narrow index of marks, materials, and system roles. | Visitors learn the visual language without an onboarding tutorial. |
+| The Foldout | The atlas expands beyond its original edge. | Jarvis and the entire ecosystem become one navigable relational drawing. |
+| The Case Folios | Bound pages give way to inserted documents. | Selected systems appear as outputs, decisions, diagrams, and dated revisions. |
+| The Margins | Annotations become more personal and less formal. | Travel observations, audio notes, and product principles reveal the maker. |
+| The Colophon | The final page lists what is active, unfinished, and next. | The checksum, archive, and contact invitation close the volume without finality. |
+
+### Signature Interaction: The Alignment Overlay
+
+Three translucent leaves represent Intent, Context, and Action. Separately they appear incomplete. As the visitor advances, the leaves align: Jarvis emerges at their intersection and the specialist agents become legible through what each layer contributes.
+
+**What it reveals:** Orchestration becomes an act of alignment rather than a technical diagram. Complexity is made coherent without being hidden.
+
+### Materials
+
+- **Cotton rag paper:** Soft tooth, archival weight, slight variation at the edge.
+- **Drafting vellum:** Transparent enough to reveal relationships, opaque enough to preserve discovery.
+- **Charcoal bookcloth:** Dry, tactile, and nearly black around the bound edge.
+- **Blackened steel:** A quiet lectern that disappears beneath the book.
+- **Aged brass:** Tiny registration corners and binding details, never decorative trim.
+- **Graphite, cobalt, and red pencil:** Thought, active system, and revision—with red used almost never.
+
+### Motion
+
+- **Layers align:** Movement occurs within the depth of paper: overlays register, separate, and reveal.
+- **Chapters replace rooms:** A chapter transition changes material or page construction, not merely content.
+- **No page-curl theater:** Pages shift with the flat, damped behavior of a designer handling a folio.
+- **Annotations arrive last:** The formal information settles before John’s handwritten observation appears.
+
+### Creative Risk
+
+The entire digital product behaves like a contemporary publishing object rather than a website. Technical depth is expressed through editorial layering.
+
+### Failure Mode
+
+It could drift into nostalgic book fetish, luxury editorial styling, or forced page-turn skeuomorphism. The instrument behavior must remain unmistakably contemporary.
+
+### Long-Term Ceiling
+
+Exceptional for essays, case studies, and a future founder narrative. Slightly less immediate than The Long Table for demonstrating living systems.
+
+## 3. The Instrument Cabinet
+
+> It feels like standing before a one-off scientific cabinet built to reveal how an ordinary life is quietly coordinated.
+
+**Distinction:** The homepage is one iconic physical object viewed frontally. Every capability has a location, label, and mechanical relationship.
+
+| Coordinate | Direction |
+|---|---|
+| Perspective | Orthographic front elevation |
+| Dominant object | A freestanding precision cabinet |
+| Light | Soft museum spot from above |
+
+### First Impression
+
+1. An empty gallery wall holds a single freestanding cabinet taller than a person. It is part pale wood, part matte aluminum, with a wide smoked-glass window at eye level and shallow archival drawers below.
+2. The composition is almost perfectly frontal. The cabinet’s geometry gives the page authority; the surrounding wall provides silence. John’s name appears on a modest maker’s plate, while the thesis is printed on a sheet clipped to the open left door.
+3. Most controls are labels rather than buttons. A single narrow drawer is slightly open, showing the edge of a cobalt card. Behind glass, Jarvis exists as a mechanical routing plate: no screen, no avatar, no dashboard.
+4. The visitor feels they have found a prototype from a design museum—functional, unexplained, and clearly made for one person’s way of thinking.
+
+### Hero
+
+- **The headline:** The statement lives on a replaceable paper brief fixed to the inside of the cabinet door, making the language feel current while the object feels permanent.
+- **The dominant object:** The cabinet itself is the hero: a recognizable silhouette with a central instrument window, six capability drawers, one decision ledger, and one personal compartment.
+- **The composition:** Strict frontal symmetry is disturbed by one open door and one extended drawer. That small imbalance proves the cabinet is being used.
+- **The curiosity engine:** The open drawer’s cobalt card is just legible enough to read “Tomorrow, 6:45 AM.” The cabinet appears to contain a prepared future.
+
+### Rooms
+
+| Room | Arrival | Purpose |
+|---|---|---|
+| The Façade | The visitor reads the cabinet as a whole. | Thesis, maker’s mark, and system architecture exist in one glance. |
+| The Glass Chamber | The view moves closer to the central routing plate. | Jarvis coordinates an authored scenario behind optical glass. |
+| The Time Drawers | Shallow trays extend in measured sequence. | Calendar, Reminder, and Morning Briefing reveal their outputs and decisions. |
+| The Movement Drawer | A wider landscape tray interrupts the modular rhythm. | Flight Agent appears with travel evidence and human constraints. |
+| The Wellbeing Archive | Ceramic-white specimen panels replace paper. | Nutrition and Health feel sensitive, calm, and deliberately bounded. |
+| The Maker’s Compartment | The lowest door opens onto a different material world. | Audio, travel, pixel history, and a personal note reveal who built the cabinet. |
+
+### Signature Interaction: The Responsibility Shutter
+
+The visitor selects a human intention on a paper card. Inside the glass, small mechanical shutters open in sequence to reveal only the systems currently responsible. When a handoff occurs, one shutter closes only after the next has accepted the work.
+
+**What it reveals:** Responsibility, boundaries, and coordination become physical. Intelligence is not represented as omniscience.
+
+### Materials
+
+- **Bleached ash veneer:** Warm, restrained, and furniture-like without domestic softness.
+- **Bead-blasted aluminum:** Door frames, drawer pulls, labels, and mechanical datum points.
+- **Smoked museum glass:** Protects the instrument and creates optical depth without blur.
+- **Porcelain enamel:** Used sparingly for sensitive wellbeing artifacts.
+- **Wool felt:** Lines the personal and audio compartment.
+- **Engraved laminate:** Tiny replaceable labels that make the object feel maintained.
+
+### Motion
+
+- **Everything is damped:** Doors, trays, and shutters move with engineered resistance and stop without rebound.
+- **Only one compartment opens:** The cabinet preserves focus by refusing simultaneous spectacle.
+- **Mechanics expose logic:** Movement reveals which part owns responsibility; it never exists as ambient theater.
+- **The façade returns:** After exploration, the cabinet closes to a calm, recognizable whole.
+
+### Creative Risk
+
+The site establishes a single icon—a cabinet with a unique silhouette—that could become as identifiable as a product form.
+
+### Failure Mode
+
+It can become overly Braun, overly literal, or frustrating if every piece of content is trapped inside a drawer metaphor. Navigation must remain direct and semantic.
+
+### Long-Term Ceiling
+
+Very high as a brand object. More constrained than the table or atlas when the body of work expands beyond personal systems.
+
+## 4. The Field Station
+
+> It feels like entering a remote research station where everyday life is observed as carefully as weather.
+
+**Distinction:** The workshop faces outward. Travel, time, health, and daily routines are treated as conditions in the world—not software categories.
+
+| Coordinate | Direction |
+|---|---|
+| Perspective | Architectural interior with horizon |
+| Dominant object | A window-side observation desk |
+| Light | Cold landscape light, warm task lamp |
+
+### First Impression
+
+1. A quiet concrete-and-timber room faces a wide, pale horizon. The view is not picturesque; it is atmospheric—an overcast expanse that makes the interior materials feel precise and sheltered.
+2. A compact observation desk sits beneath the window. On it: a folded paper schedule, a small travel object, a ceramic cup, a narrow smoked-glass instrument, and a field notebook held open by an aluminum clip.
+3. The headline is printed on the notebook’s first visible page. John’s identity appears as a station label fixed to the wall, not a personal billboard. The room is spacious enough to hear itself.
+4. One slim mark on the glass instrument corresponds to a handwritten note in the book. The digital and physical observations appear to be studying the same day from different angles.
+
+### Hero
+
+- **The headline:** The thesis belongs to the open field notebook in the near foreground, with one sentence beneath it: Systems should notice the friction before they add to it.
+- **The dominant object:** The window-side station dominates: landscape, desk, notebook, and a compact instrument form one balanced environmental portrait.
+- **The composition:** Two-thirds quiet atmosphere, one-third concentrated evidence. The horizon stabilizes the page while the desk gathers narrative detail.
+- **The curiosity engine:** A timestamped strip emerges from the instrument and rests across the notebook margin, joining an automated observation to John’s handwritten one.
+
+### Rooms
+
+| Room | Arrival | Purpose |
+|---|---|---|
+| The Arrival Deck | The visitor takes in the room and horizon. | The thesis feels connected to a life being lived, not an industry trend. |
+| The Observation Desk | The view moves close enough to read one day. | Morning Briefing, Calendar, and Reminder appear as a coordinated routine. |
+| The Dispatch Wall | Maps, tickets, and constraints replace abstract navigation. | Flight Agent is revealed through real movement and uncertainty. |
+| The Quiet Clinic | The light softens and the materials become ceramic and cloth. | Health and Nutrition are treated with sensitivity, boundaries, and care. |
+| The Listening Bench | The window closes from view; felt and wood absorb the room. | Field recordings and audio objects reveal attention beyond engineering. |
+| The Night Log | The task light remains while the horizon disappears. | Lab notes, unresolved questions, and future systems close the day. |
+
+### Signature Interaction: The Day Strips
+
+A set of narrow paper strips records moments from one real day: waking, travel, a schedule change, a reminder, a meal, and recovery. As they align on the desk, subtle marks reveal where different agents shared context and where John deliberately kept control.
+
+**What it reveals:** The ecosystem is understood as infrastructure around a life, never as a collection of AI products.
+
+### Materials
+
+- **Honest concrete:** Pale, smooth, and architectural—not brutalist theater.
+- **Oiled birch:** The working desk and shelves; lighter and more utilitarian than luxury walnut.
+- **Wool felt:** Acoustic panels and the listening bench.
+- **Glazed ceramic:** Human objects and wellbeing artifacts.
+- **Weathered aluminum:** Clips, rails, station labels, and travel-worn details.
+- **Field paper:** Folded, dated, and allowed to carry use.
+
+### Motion
+
+- **The room changes by attention:** Light and focus move between desk, wall, clinic, and listening bench; the architecture stays stable.
+- **Paper records consequence:** System activity produces strips, notes, and placements instead of luminous effects.
+- **The horizon barely moves:** Atmosphere changes slowly enough to feel like time, never like a looping background.
+- **Transitions feel walked:** Each room is entered by a change in scale and acoustic character, not a page wipe.
+
+### Creative Risk
+
+It rejects the inward-looking AI laboratory and places technology in weather, travel, bodies, routines, and time. It is the most human interpretation.
+
+### Failure Mode
+
+It depends on exceptional environmental imagery and can drift into an architecture studio, outdoor brand, or travel journal. The system instrument must retain equal authority.
+
+### Long-Term Ceiling
+
+High for a founder with a broad life philosophy. Less ownable as a pure digital identity than the table, atlas, or cabinet.
+
+## 5. The Listening Room
+
+> It feels like hearing a complex machine resolve into a perfectly balanced arrangement—before a single sound is played.
+
+**Distinction:** Orchestration is interpreted as composition, routing, silence, and attentive listening rather than computation.
+
+| Coordinate | Direction |
+|---|---|
+| Perspective | Seated, intimate interior |
+| Dominant object | A bespoke routing console |
+| Light | Low warm pool over silver controls |
+
+### First Impression
+
+1. A small acoustically treated room is viewed from the position of someone sitting down to listen. Dark wool walls remove visual noise. A low walnut console occupies the lower edge, while a single silver instrument plate rests at its center.
+2. The headline is printed on a heavy record-sleeve-like sheet placed to the left—not styled as music branding, but handled with the care of liner notes. John’s name is engraved near the console’s power switch.
+3. There are no screens full of meters. Six small labels identify the specialist systems. One physical route is set in cobalt; all others remain graphite grey. The empty wall ahead creates almost theatrical silence.
+4. A tiny field recorder sits closed on the far right. It is the only object that suggests the room contains more than engineered systems.
+
+### Hero
+
+- **The headline:** The statement lies on the console as a piece of authored listening material. Its typesetting is spacious and almost quiet enough to miss.
+- **The dominant object:** The silver routing plate dominates. Jarvis is not a channel; it is the logic that assigns a source to the right sequence of specialist paths.
+- **The composition:** A low horizontal horizon of material occupies the bottom third. The upper two-thirds are dark acoustic silence, broken by one precise wall annotation.
+- **The curiosity engine:** One routed path is already prepared, but the source label is hidden beneath the headline sheet. The visitor senses an arrangement waiting to be understood.
+
+### Rooms
+
+| Room | Arrival | Purpose |
+|---|---|---|
+| The Foyer | A paper sleeve introduces the thesis before the equipment. | The experience begins with authored intent, not controls. |
+| The Routing Console | Specialist systems become distinct paths with different responsibilities. | Jarvis demonstrates orchestration through one silent arrangement. |
+| The Isolated Tracks | Each system is heard conceptually on its own. | Case studies expose contribution, limitations, and decisions. |
+| The Mix Room | The separate paths return to one coherent day. | The ecosystem’s value becomes the quality of the whole experience. |
+| The Field Recording Shelf | The metaphor becomes personal and literal. | Travel, sound, and observation reveal John’s attention to the world. |
+| The Master Log | A restrained list records versions, retired experiments, and open questions. | Craft is shown as iteration rather than perfection. |
+
+### Signature Interaction: The Silent Mix
+
+The visitor selects “Protect my morning.” Paths are assigned one by one: briefing establishes context, calendar protects time, reminder holds an obligation. No sound plays. Instead, visual noise disappears as the arrangement becomes coherent. Optional audio is offered only afterward.
+
+**What it reveals:** Intelligence is expressed as the removal of noise and the balancing of responsibility—not as more output.
+
+### Materials
+
+- **Dark wool felt:** Absorbs visual and acoustic noise; warm, not nightclub black.
+- **Oiled walnut:** One personal, resonant surface used with restraint.
+- **Brushed aluminum:** The routing plate, labels, and decisive controls.
+- **Ivory sleeve stock:** Carries narrative, field notes, and case-study language.
+- **Smoked acrylic:** A narrow cover over active routes, not a glass dashboard.
+- **Cobalt enamel:** One active route marker, dense and tactile.
+
+### Motion
+
+- **Behavior has tempo:** Actions occur in measured phrases with deliberate rests between responsibility changes.
+- **Silence is visual subtraction:** A successful outcome removes clutter instead of adding celebration.
+- **Controls move minimally:** A route engages with one short mechanical action and remains set.
+- **Sound is always optional:** The world never assumes that an audio metaphor requires audio playback.
+
+### Creative Risk
+
+It turns John’s interest in audio into the organizing logic of the portfolio while making system orchestration emotionally legible.
+
+### Failure Mode
+
+The metaphor may constrain future work or make the portfolio resemble a music-technology brand. Too many knobs, meters, or waveforms would immediately become a themed interface.
+
+### Long-Term Ceiling
+
+Distinctive but narrower. Best as a signature room within another concept rather than the decade-long master identity.
+
+## 6. The Optical Chamber
+
+> It feels like entering a dark room where relationships become visible only when they matter.
+
+**Distinction:** A cinematic chamber of selective visibility. The environment withholds almost everything until causality gives it reason to appear.
+
+| Coordinate | Direction |
+|---|---|
+| Perspective | Frontal, room-scale projection |
+| Dominant object | A wall-sized optical plate |
+| Light | Near-darkness with one warm threshold |
+
+### First Impression
+
+1. The visitor begins in a small pool of warm light. A sheet of paper on a blackened-steel ledge carries the headline. Beyond it, the room falls into charcoal darkness—not outer space, not a glowing interface, simply a museum chamber before an exhibit activates.
+2. A wall-sized optical plate occupies the distance. Its surface is smoked and nearly matte. Fine etched coordinates are only visible where the grazing light catches them. Jarvis is a location in the geometry, not a central orb.
+3. The scale is architectural. The visitor stands in front of the system rather than holding it. A single narrow cobalt registration line confirms that the plate has depth.
+4. The chamber feels calm enough to be trusted, but charged enough that one deliberate action could change the room.
+
+### Hero
+
+- **The headline:** The thesis remains on warm paper at the threshold, physically separate from the dark chamber. Human language enters before system behavior.
+- **The dominant object:** The optical plate dominates by scale and darkness. It carries the entire ecosystem as etched latent structure.
+- **The composition:** A small warm foreground against a large dark background. The eye moves from readable paper to barely visible architecture.
+- **The curiosity engine:** One coordinate on the optical plate corresponds to a tiny notch cut into the paper. The human brief and system chamber are clearly related, but the connection has not yet activated.
+
+### Rooms
+
+| Room | Arrival | Purpose |
+|---|---|---|
+| The Warm Threshold | Paper, identity, and thesis remain fully legible. | The visitor enters through human intent rather than spectacle. |
+| The Dark Chamber | The optical plate reveals only its registration system. | Scale and restraint create anticipation. |
+| The Causal Projection | One authored scenario illuminates relationships in strict order. | Jarvis and specialist responsibilities become comprehensible. |
+| The Evidence Wall | Illumination narrows into isolated project specimens. | Claims are paired with decisions, outputs, and boundaries. |
+| The Side Archive | A lit drawer interrupts the dark architecture. | Personal artifacts and pixel lineage restore intimacy. |
+| The Daylight Exit | The final room returns to warm paper and open light. | Future work and contact feel like continuation, not a dramatic finale. |
+
+### Signature Interaction: The Responsibility Projection
+
+A chosen intention sends one measured line across the optical plate. At each handoff, the receiving system’s etched label catches light while the previous one falls back into structure. The room never shows the whole network at equal brightness.
+
+**What it reveals:** Attention and responsibility are the same visual act. The system is intelligent because it knows what should remain invisible.
+
+### Materials
+
+- **Blackened steel:** Architectural frame and threshold ledge; dry, not glossy.
+- **Smoked optical glass:** Wall-scale but nearly matte, with real visual depth.
+- **Etched aluminum:** Coordinates and system labels that appear under grazing light.
+- **Warm cotton paper:** Human language and case-study evidence remain tactile.
+- **White ceramic:** A few precise handles and archive markers.
+- **Cobalt marking film:** A single active registration path, never ambient glow.
+
+### Motion
+
+- **Visibility is earned:** Nothing appears because time passed; relationships become visible because responsibility moved.
+- **Light travels, objects do not:** The chamber remains architectural while illumination clarifies causality.
+- **Activation is narrow:** Only one path is bright enough to dominate; the system never becomes a glowing web.
+- **Every sequence returns to dark:** Consequences remain as text and state while spectacle leaves the room.
+
+### Creative Risk
+
+It takes the Luminous Workshop’s instrument layer to room scale and makes selective visibility the entire identity.
+
+### Failure Mode
+
+This is closest to the cinematic AI-lab cliché. Small mistakes create a HUD, control room, or sci-fi installation. It is dark-mode dependent and the least forgiving for accessibility.
+
+### Long-Term Ceiling
+
+High immediate impact, lower long-term distinctiveness. Many technology brands already occupy adjacent visual territory.
+
+## Ranking
+
+The concepts were ranked by distinctiveness, strategic fit, scalability, and decade-long ceiling.
+
+1. **The Long Table.** Highest. The table can become an ownable stage for every future project, company, essay, and artifact without changing the identity.
+2. **The Binding Room.** Exceptional for essays, case studies, and a future founder narrative. Slightly less immediate than The Long Table for demonstrating living systems.
+3. **The Instrument Cabinet.** Very high as a brand object. More constrained than the table or atlas when the body of work expands beyond personal systems.
+4. **The Field Station.** High for a founder with a broad life philosophy. Less ownable as a pure digital identity than the table, atlas, or cabinet.
+5. **The Listening Room.** Distinctive but narrower. Best as a signature room within another concept rather than the decade-long master identity.
+6. **The Optical Chamber.** High immediate impact, lower long-term distinctiveness. Many technology brands already occupy adjacent visual territory.
+
+## Canonical Selection: The Long Table
+
+### It turns the portfolio into a stage, not a style.
+
+Apple owns the product-on-stage. Stripe owns the explanatory editorial system. Arc owns expressive software personality. John can own the long workbench: one place where systems, decisions, experiments, failures, sound, travel, and future companies are continually placed, connected, and examined.
+
+### Why It Compounds
+
+The table is recognizable in silhouette, flexible in content, physical without nostalgia, cinematic without darkness, and perfectly aligned with “evidence of a curious person at work.”
+
+It also contains the other worlds naturally: an atlas can lie open on it, an instrument can be inset into it, a listening corner can extend from it, and an archive can wait at its far end.
+
+> **The decisive caution**
+>
+> Do not choose The Optical Chamber because it produces the most dramatic first screenshot. That image would be impressive now and familiar soon. Choose the world that can accumulate ten years of work without becoming visual debt.
+
+## If We Choose The Long Table
+
+1. **Protect the physical logic.** Everything must be placed, inset, clipped, written, aligned, or connected. Nothing floats without a reason.
+2. **Avoid the 3D demo trap.** The table is a compositional system first. Depth supports hierarchy; it is never a game environment.
+3. **Make the bench unmistakable.** Its proportion, rail, glass bay, checksum marks, and object spacing should form a repeatable signature.
+4. **Design an equivalent reading path.** The environment must remain coherent with reduced motion, keyboard navigation, and no perspective effects.
+
+## Final Selection Test
+
+- **Can it be recognized without color?** Silhouette, perspective, rhythm, and material contrast should identify the world.
+- **Can it host an unfinished idea?** A real workshop must make experiments feel intentional rather than incomplete.
+- **Can it become quieter over time?** As content grows, the grammar should preserve calm instead of demanding more spectacle.
+- **Can only John fill it?** The world is successful only when his systems, decisions, sound, travel, and pixel lineage complete it.
+
+## Related Documents
+
+- [Creative Direction](./03-creative-direction.md)
+- [Homepage Specification](./05-homepage-specification.md)
+- [Design Principles](./06-design-principles.md)

--- a/docs/design/05-homepage-specification.md
+++ b/docs/design/05-homepage-specification.md
@@ -1,0 +1,643 @@
+# The Long Table Homepage Specification
+
+> From environment to digital product.
+
+The complete homepage narrative, section contracts, evidence model, human layer, navigation, and handoff criteria—without literal table imagery or traditional portfolio patterns.
+
+## Homepage Product Definition
+
+### A vertical journey along an implied workbench.
+
+The Long Table is translated into alignment, accumulation, material contrast, and spatial progression—not a photograph or literal 3D scene. Visitors move from the near edge to the far end through seven necessary narrative states.
+
+| Physical metaphor | Digital translation |
+|---|---|
+| Table | A persistent horizontal datum |
+| Walking | Vertical narrative progression |
+| Objects | Evidence with provenance |
+| Instrument | The active ecosystem plane |
+| Accumulation | Visible iteration and history |
+
+## Narrative Spine
+
+```text
+01  Arrival        The Near Edge
+      ↓
+02  Discovery      The Instrument Bay
+      ↓
+03  Understanding  One Day, Many Systems
+      ↓
+04  Evidence       Objects on the Bench
+      ↓
+05  Judgment       The Decision Ledger
+      ↓
+06  Person         The Maker’s Edge
+      ↓
+07  Invitation     The Far End
+```
+
+### Narrative Test
+
+Remove any chapter and the story breaks:
+
+- No arrival means no thesis.
+- No discovery means no ecosystem.
+- No understanding means no orchestration.
+- No evidence means no proof.
+- No judgment means no seniority.
+- No person means no warmth.
+- No invitation means no continuation.
+
+### Rhythm Across the Page
+
+1. **Arrival is sparse.** Language and negative space establish confidence.
+2. **Discovery gains structure.** The instrument introduces relational density.
+3. **Understanding becomes active.** One scenario carries the page’s strongest behavior.
+4. **Evidence becomes tactile.** Artifacts accumulate without becoming a grid.
+5. **Judgment slows the visitor.** Decisions demand reading, not scanning.
+6. **The person warms the room.** A few discovered artifacts loosen the precision.
+7. **Invitation returns to space.** The table ends with openness, not footer density.
+
+## 01. Arrival — The Near Edge
+
+### Purpose
+
+Establish John, the life-sized ambition, and the Long Table’s digital grammar before asking the visitor to do anything.
+
+### Emotional Goal
+
+Composure first, then curiosity. The visitor should feel welcomed into a serious working environment—not captured by a campaign.
+
+### Visual Hierarchy
+
+1. Primary: “Everyday life, thoughtfully automated.” set on a broad warm field.
+2. Secondary: John Moses — Software Engineer at Microsoft / builder of connected intelligent systems.
+3. Tertiary: a compact navigation rail and one understated path into the system.
+4. Counterweight: the edge of a dark instrument plane entering from the far side, only partly understood.
+
+### What the Visitor Learns
+
+- John builds systems around ordinary human friction.
+- His work is connected by one long-term thesis.
+- Microsoft is a credibility signal, not the subject of the site.
+- The environment will reveal work through artifacts and relationships.
+
+### What the Visitor Does
+
+- Continue naturally into the system.
+- Use the navigation rail to move directly to System, Evidence, Notes, or Contact.
+- Select the quiet invitation “See the system at work” for immediate orientation.
+
+### What Stays Still
+
+- The thesis, John’s identity, and the page’s horizontal datum rail.
+- The broad warm field; it behaves like a stable working surface.
+- All personal and professional claims.
+
+### What Moves
+
+- One cobalt registration mark appears where the warm field meets the dark instrument edge.
+- The instrument plane gains clarity only as the visitor approaches it.
+- No other element performs an entrance.
+
+### Why This Section Exists
+
+Without this quiet threshold, the system demonstration becomes a product demo and John disappears behind it.
+
+### Required Content
+
+- **Headline:** Everyday life, thoughtfully automated.
+- **Identity:** John Moses — Software Engineer at Microsoft.
+- **Descriptor:** I build connected systems for time, travel, health, and the small decisions that shape a day.
+- **Invitation:** See the system at work.
+
+### Transition
+
+The dark plane occupies more of the visual field, and the cobalt registration mark becomes the first coordinate inside it.
+
+## 02. Discovery — The Instrument Bay
+
+### Purpose
+
+Reveal that AI-Lab is one ecosystem and Jarvis is its coordinating layer—not one project among many.
+
+### Emotional Goal
+
+Turn curiosity into orientation. The visitor should feel that a complex system is becoming legible without being simplified into marketing.
+
+### Visual Hierarchy
+
+1. Primary: one bounded dark instrument field embedded in the warm page.
+2. Center of gravity: Jarvis as a labeled coordinating position, never a logo, face, orb, or chat window.
+3. Capability regions: Daily Intelligence, Time, Movement, and Wellbeing.
+4. Specialists appear within those regions: Morning Briefing, Calendar, Reminder, Flight, Nutrition, and Health.
+
+### What the Visitor Learns
+
+- Jarvis interprets intent and coordinates specialized capabilities.
+- Agents share context but retain clear responsibilities.
+- The ecosystem is organized around human outcomes, not technology categories.
+- Some capabilities are mature, some experimental, and those differences are stated honestly.
+
+### What the Visitor Does
+
+- Choose an intention: Start my day, Plan travel, Protect my time, or Understand my health.
+- Focus any capability to reveal its role, dependencies, current state, and one real artifact.
+- Move between outcome view and system view without leaving the composition.
+
+### What Stays Still
+
+- The ecosystem’s base geometry and capability regions.
+- Jarvis’s position within the system.
+- The plain-language definition of each responsibility.
+
+### What Moves
+
+- Only relationships relevant to the chosen intention gain emphasis.
+- A responsibility line travels from initiator to receiver in causal order.
+- Unrelated systems recede but remain spatially present.
+
+### Why This Section Exists
+
+This is the conceptual turn: visitors stop seeing a portfolio and begin understanding a system builder.
+
+### Required Content
+
+- **System label:** AI-Lab / an evolving ecosystem for everyday intelligence.
+- **Jarvis label:** Intent, context, orchestration.
+- Four intention controls written in human language.
+- Honest capability states: In daily use, On the bench, Under test, Retired with lessons.
+
+### Transition
+
+The selected intention remains active while the surrounding system clears space for one complete demonstration.
+
+## 03. Understanding — One Day, Many Systems
+
+### Purpose
+
+Demonstrate orchestration through a concrete human scenario before exposing architecture or project depth.
+
+### Emotional Goal
+
+Deliver the homepage’s moment of wonder: not spectacle, but the realization that several quiet systems are cooperating around one life.
+
+### Visual Hierarchy
+
+1. Primary: one human intention and its resolved outcome.
+2. Secondary: a sequence of responsibility handoffs across Jarvis and the relevant agents.
+3. Supporting: actual outputs produced at each step.
+4. Background: the larger ecosystem remains visible as latent structure.
+
+### What the Visitor Learns
+
+- The value lives between agents, not only inside them.
+- Jarvis coordinates rather than pretending to do everything.
+- Automation has boundaries and moments of human confirmation.
+- The system produces useful outcomes, not merely responses.
+
+### What the Visitor Does
+
+- Advance through the selected scenario one responsibility at a time.
+- Pause on any handoff to inspect the context received, decision made, and output produced.
+- Switch among three authored scenarios without resetting the visitor’s place in the story.
+
+### What Stays Still
+
+- The original human intention.
+- The final desired outcome.
+- The larger system map as spatial context.
+
+### What Moves
+
+- Responsibility advances in strict causal order.
+- Outputs accumulate beside the sequence like objects placed on a bench.
+- Completed paths cool into historical traces instead of disappearing.
+
+### Why This Section Exists
+
+A system diagram proves structure; a scenario proves understanding. This section makes the architecture emotionally legible.
+
+### Required Content
+
+- Primary scenario: Plan a trip.
+- Jarvis identifies intent and relevant constraints.
+- Calendar contributes timing and obligations.
+- Flight evaluates options and uncertainty.
+- Reminder accepts the unresolved future task.
+- Human approval remains visible where the system should not decide alone.
+
+### Transition
+
+The resolved scenario condenses into a labeled evidence bundle, introducing the next part of the table.
+
+## 04. Evidence — Objects on the Bench
+
+### Purpose
+
+Replace claims with artifacts that prove the systems exist, evolve, and contain real product and engineering judgment.
+
+### Emotional Goal
+
+Trust. The visitor should feel invited to inspect the work closely, including its rough edges.
+
+### Visual Hierarchy
+
+1. Primary: one large artifact at a time—actual output, screenshot, architecture drawing, notebook page, or deployed behavior.
+2. Secondary: a decision annotation attached directly to that artifact.
+3. Tertiary: provenance—date, state, system, and what changed.
+4. Supporting evidence sits nearby in smaller physical relationships, never equal cards.
+
+### What the Visitor Learns
+
+- What each capability actually produces.
+- How the system changed through iteration.
+- Which decisions mattered more than the technology choices.
+- Where the work is mature, uncertain, or unfinished.
+
+### What the Visitor Does
+
+- Change the reading depth of an artifact: Experience, Decisions, Architecture.
+- Open the evidence bundle without leaving its place on the table.
+- Follow a dated revision to see what changed and why.
+- Move from an artifact back to the ecosystem role it supports.
+
+### What Stays Still
+
+- The primary artifact and its provenance.
+- The system’s honest maturity state.
+- The human outcome the artifact serves.
+
+### What Moves
+
+- Annotation layers replace one another while preserving the artifact’s position.
+- A related sketch or output may align beside the primary evidence.
+- No carousel advances automatically and no object floats for decoration.
+
+### Why This Section Exists
+
+This section converts taste and ambition into credibility. Removing it would leave a beautiful thesis with insufficient proof.
+
+### Required Content
+
+- Jarvis orchestration: an actual scenario output plus system sketch.
+- Movement: a Flight Agent decision with uncertainty and a rejected approach.
+- Time: a Calendar or Reminder handoff with an iteration note.
+- Wellbeing: a Health or Nutrition artifact that clearly shows privacy and automation boundaries.
+- One deployment or commit excerpt only when it explains a meaningful product change.
+
+### Transition
+
+A visible annotation asks not “What did this use?” but “Why was it built this way?” and leads into the decision ledger.
+
+## 05. Judgment — The Decision Ledger
+
+### Purpose
+
+Show the quality of John’s reasoning: constraints, tradeoffs, failed experiments, boundaries, and deliberate non-features.
+
+### Emotional Goal
+
+Respect. The visitor should recognize senior product and engineering judgment rather than simply technical activity.
+
+### Visual Hierarchy
+
+1. Primary: one consequential decision written in plain language.
+2. Secondary: the options considered and evidence that changed the direction.
+3. Tertiary: the resulting constraint, principle, or system boundary.
+4. Failures are treated with the same visual care as successful decisions.
+
+### What the Visitor Learns
+
+- John knows when not to automate.
+- He treats uncertainty, privacy, failure, and maintenance as product concerns.
+- Architecture follows human needs and operating constraints.
+- The work is an evolving practice, not a collection of finished demos.
+
+### What the Visitor Does
+
+- Open “What we tried,” “What surprised me,” and “What changed.”
+- Compare the rejected path with the chosen one.
+- Follow a decision forward to the systems it affected.
+
+### What Stays Still
+
+- The final decision statement.
+- The date and project context.
+- The consequence of the decision.
+
+### What Moves
+
+- Alternatives align temporarily beside the decision, then recede.
+- Affected systems receive a quiet shared marker.
+- Nothing celebrates failure; the interface simply makes learning inspectable.
+
+### Why This Section Exists
+
+Evidence shows that John built. Judgment shows why people should trust him with systems, products, teams, and companies.
+
+### Required Content
+
+- A decision to preserve human confirmation.
+- A failed orchestration approach and the signal that exposed it.
+- A privacy or context boundary in Health or Nutrition.
+- A complexity removed from Jarvis rather than added.
+- A short recurring label: What surprised me.
+
+### Transition
+
+The precision of the ledger loosens. A handwritten note, photograph edge, or sound object appears outside the system grid.
+
+## 06. Person — The Maker’s Edge
+
+### Purpose
+
+Reveal the life that teaches John what to notice, without turning the portfolio into a personal feed or biography.
+
+### Emotional Goal
+
+Warmth and recognition. The visitor should feel they have discovered the maker, not been presented with a personality brand.
+
+### Visual Hierarchy
+
+1. Primary: a changing but tightly edited arrangement of three personal artifacts.
+2. Secondary: one sentence connecting observation to the way John builds.
+3. Tertiary: quiet provenance—place, date, book title, recording, recipe note, or camera.
+4. Microsoft remains a small maker credential, never a branded feature.
+
+### What the Visitor Learns
+
+- Travel and California shape how John observes time, movement, and place.
+- Music and field recording sharpen his attention to rhythm, silence, and interaction.
+- Books and engineering notebooks show an ongoing habit of inquiry.
+- Sunday Pasta Co. reveals care for craft, ritual, hospitality, and making outside software.
+- There is a real person behind the precision.
+
+### What the Visitor Does
+
+- Inspect an artifact to reveal one concise field note.
+- Play a short field recording only by explicit choice.
+- Open a Sunday Pasta Co. label, recipe card, or packaging study as a physical-making story.
+- Follow a notebook surprise back to the system decision it influenced.
+
+### What Stays Still
+
+- The artifact arrangement and its physical scale.
+- The absence of follower counts, feeds, and social proof.
+- One small, unstaged image of John or his hand at work.
+
+### What Moves
+
+- Only the selected artifact reveals its note.
+- Audio creates no visualizer; the room remains visually quiet.
+- Personal references never auto-rotate or compete with one another.
+
+### Why This Section Exists
+
+Without this room, the site is impressive but emotionally sealed. This section explains why these systems exist in John’s life.
+
+### Required Content
+
+- A California light or travel photograph with a field note.
+- A field recording or piece of audio hardware.
+- A book with one marked passage and John’s margin response.
+- A Sunday Pasta Co. physical artifact.
+- An engineering notebook page titled “What surprised me.”
+- A restrained Microsoft maker label: building software at scale; no logo wall.
+
+### Transition
+
+The objects become fewer until only an open surface, the datum rail, and one invitation remain.
+
+## 07. Invitation — The Far End
+
+### Purpose
+
+Turn accumulated trust into a clear path for conversation without changing tone or becoming a conversion section.
+
+### Emotional Goal
+
+Possibility. The visitor should feel invited to bring an ambitious problem to the table.
+
+### Visual Hierarchy
+
+1. Primary: one sentence with generous space around it.
+2. Secondary: a direct contact action.
+3. Tertiary: GitHub, LinkedIn, and résumé as compact reference links—not destination-sized buttons.
+4. Final mark: the pixel checksum and the current AI-Lab state.
+
+### What the Visitor Learns
+
+- John is interested in intelligent systems, thoughtful products, difficult engineering, and future-facing collaborations.
+- The work is ongoing.
+- There is a simple, human way to reach him.
+
+### What the Visitor Does
+
+- Start an email with visible address and clear purpose.
+- Open the compact work index or professional references.
+- Return to any part of the table through the navigation rail.
+
+### What Stays Still
+
+- The invitation sentence and direct email address.
+- The open warm surface.
+- The checksum as John’s signature.
+
+### What Moves
+
+- The cobalt context trace settles into the checksum rather than performing a finale.
+- The navigation rail remains available.
+- Nothing confetti-like, celebratory, or sales-driven occurs.
+
+### Why This Section Exists
+
+The table needs a far edge: a point where inspection becomes participation and the visitor can bring something new into the workshop.
+
+### Required Content
+
+- **Invitation:** If you are building a system that should feel more useful than complicated, I would like to hear about it.
+- **Primary action:** Write to John.
+- **References:** GitHub, LinkedIn, résumé.
+- **Status:** AI-Lab is ongoing.
+
+### Ending
+
+The page ends in open space rather than a dense footer, leaving the emotional sense that the work continues beyond the viewport.
+
+## Evidence Presentation Model
+
+### Artifacts are assembled, not carded.
+
+Each story begins with one primary piece of real work. Supporting evidence sits in a deliberate physical relationship around it. The visitor inspects a working assembly rather than browsing a shelf of equally polished projects.
+
+### Anatomy of an Evidence Bundle
+
+```text
+┌───────────────────────────────────────┬──────────────────────────┐
+│ PRIMARY ARTIFACT                      │ Decision note            │
+│                                      ├──────────────────────────┤
+│ Actual system output or              │ Provenance strip         │
+│ interface state                      ├──────────────────────────┤
+│                                      │ Supporting evidence      │
+│ Large and unobstructed               ├──────────────────────────┤
+│                                      │ Depth lens               │
+└───────────────────────────────────────┴──────────────────────────┘
+```
+
+The artifact remains visually stable while explanation layers change around it. It is never covered by marketing copy.
+
+- **Decision note:** One choice that materially shaped the artifact.
+- **Provenance strip:** System · status · date · revision.
+- **Supporting evidence:** Sketch, commit excerpt, failed version, or deployment note.
+- **Depth lens:** Experience · Decisions · Architecture.
+
+### Six Evidence Types
+
+| Type | Question | Form |
+|---|---|---|
+| Output | What the system produced | Screenshot, briefing, recommendation, reminder, itinerary, or report. |
+| Decision | Why it behaves this way | A consequential choice with context, alternatives, and outcome. |
+| Tradeoff | What was protected | Speed versus trust, automation versus confirmation, breadth versus reliability. |
+| Change | How the work evolved | A dated revision, deployment note, or meaningful commit explained in human terms. |
+| Failure | What did not survive | A rejected experiment and the evidence that ended it. |
+| Boundary | Where the system stops | Privacy, uncertainty, maintenance, or a decision deliberately left to a person. |
+
+### Artifact Selection Rules
+
+1. **Show only what is real.** Use actual outputs and states; redact sensitive details without recreating a cleaner fiction.
+2. **Choose explanatory artifacts.** A rough diagram with a consequential decision outranks a polished screenshot with no story.
+3. **Preserve evidence of change.** Annotations, dates, and rejected versions make accumulated work visible.
+4. **State maturity plainly.** In daily use, On the bench, Under test, or Retired with lessons.
+
+### Patterns Explicitly Excluded
+
+1. **No equal project cards.** Jarvis and specialist agents cannot be flattened into one repeated tile.
+2. **No screenshot galleries.** Every visual must carry a reason, decision, or consequence.
+3. **No commit theater.** A code-history excerpt appears only when it explains a product change.
+4. **No architecture wallpaper.** Diagrams must answer a question raised by the artifact.
+
+## Human Storytelling Model
+
+### Personal details are discovered at the edges of the work.
+
+The homepage never pauses for a conventional biography. John appears through the artifacts he keeps, the observations he records, and the values that cross from life into system design.
+
+### Travel + California
+
+Field photographs and travel fragments appear beside Movement and time-based work. Their captions focus on what John noticed—not where he went.
+
+### Music + Listening
+
+One field recording and one piece of audio hardware appear at the Listening Corner. They connect silence, rhythm, and signal to interaction judgment.
+
+### Books + Notebooks
+
+A marked passage may sit beside a decision it influenced. Engineering notebook pages are labeled by surprise or changed belief, never presented as decorative handwriting.
+
+### Sunday Pasta Co.
+
+A recipe card, label, packaging proof, or serving ritual becomes evidence of physical craft, hospitality, iteration, and care outside software.
+
+### Microsoft’s Role
+
+1. **Identity, not borrowed brand.** Software Engineer at Microsoft appears in the opening identity line and professional reference.
+2. **Scale without confidential detail.** A short note may explain that John builds software used at scale, without workplace case studies or brand mimicry.
+3. **No logo as proof.** The name carries enough credibility; the portfolio must establish John’s independent point of view.
+
+### Discovery Rules
+
+1. **Three artifacts at once.** The human layer remains edited and spatially calm.
+2. **One sentence per artifact.** Personal notes should reward curiosity without becoming captions for a lifestyle feed.
+3. **Connect life to judgment.** Every artifact reveals attention, ritual, craft, movement, sound, or changed belief.
+4. **No feeds or counters.** The person is present through meaning, not activity volume.
+
+### Recurring Human Device
+
+“What surprised me” appears throughout the homepage as a small notebook annotation. It is the bridge between engineering evidence and John’s living curiosity.
+
+## Homepage Navigation
+
+### Navigation behaves like a datum rail, not a themed control panel.
+
+The rail provides ordinary, reliable orientation while the page carries the metaphor. Visitors can follow the narrative or move directly to the evidence they need.
+
+```text
+JOHN MOSES                    SYSTEM    EVIDENCE    NOTES    CONTACT
+──────────────────────────────────────────────────────────────────
+```
+
+### Primary Destinations
+
+- **System:** Returns to the AI-Lab ecosystem and authored scenarios.
+- **Evidence:** Moves to the first artifact assembly, not a project listing.
+- **Notes:** Opens lab notes, decisions, experiments, and field observations.
+- **Contact:** Moves to the Far End and its direct invitation.
+
+### Secondary Orientation
+
+- **Workbench index:** A compact index lists capabilities, artifacts, notes, and states for visitors who prefer direct lookup.
+- **Current context:** Inside the instrument, a small label states the active intention and participating systems.
+- **Return path:** Every deep artifact links back to its role in the ecosystem.
+- **Professional references:** GitHub, LinkedIn, and résumé remain compact at the Far End.
+
+### Jarvis Rule
+
+Jarvis is the operating logic, not global navigation.
+
+Jarvis coordinates scenarios, carries context between capabilities, and preserves the visitor’s system orientation. It never becomes a floating assistant, conversational overlay, mascot, or replacement for clear navigation.
+
+### Usability Boundary
+
+The Long Table metaphor governs composition and storytelling. It does not rename familiar actions, conceal destinations, require horizontal travel, or make visitors manipulate objects to access essential content.
+
+## Visual Design and Build Handoff
+
+### The homepage is complete when these contracts are visible.
+
+This is the minimum coherent product. Additional effects, artifacts, or personal details should not be added until the seven-part narrative works without them.
+
+### Composition Contract
+
+1. **One horizontal datum.** Every room visibly belongs to the same long working surface.
+2. **Warm bench, dark instrument.** Reading and evidence live on the bench; active system behavior lives in one bounded instrument plane.
+3. **One focal object per room.** Hierarchy must remain obvious before details are read.
+4. **Objects accumulate with provenance.** Artifacts carry system, state, date, and reason for inclusion.
+5. **Silence separates density.** The page provides space after the system demonstration and before the invitation.
+
+### Behavior Contract
+
+1. **Intent causes motion.** No ambient performance and no decorative restlessness.
+2. **Responsibility moves in order.** Initiator, transfer, receiver, consequence.
+3. **Selection persists.** The visitor’s chosen scenario and reading depth remain stable while inspecting.
+4. **Evidence stays anchored.** Annotation changes around a primary artifact without displacing it.
+5. **The page remains a website.** Navigation, links, reading, and contact are direct even when the environment is expressive.
+
+### Required Content Before Visual Production
+
+#### System Truth
+
+Current Jarvis role, agent responsibilities, maturity states, real handoffs, and boundaries safe to publish.
+
+#### Three Authored Scenarios
+
+Plan travel, protect time, and understand wellbeing—each with inputs, decisions, outputs, and human confirmation points.
+
+#### Evidence Assemblies
+
+At least four strong primary artifacts, each paired with a meaningful decision, provenance, and one supporting trace of iteration.
+
+#### Human Artifacts
+
+A California or travel photograph, field recording, book note, Sunday Pasta Co. object, engineering notebook page, and one restrained image of John at work.
+
+## Emotional Memory
+
+> John notices the invisible friction in everyday life—and cares enough to build calm, thoughtful systems that make it disappear.
+
+## Related Documents
+
+- [Information Architecture](./02-information-architecture.md)
+- [Creative Direction](./03-creative-direction.md)
+- [Design Principles](./06-design-principles.md)
+- [Open Questions](./07-open-questions.md)

--- a/docs/design/06-design-principles.md
+++ b/docs/design/06-design-principles.md
@@ -1,0 +1,199 @@
+# Design Principles
+
+This document collects the canonical principles and constraints stated throughout the design foundation. The language is preserved from the source documents.
+
+## Product Principles
+
+1. **Human outcome before technical mechanism.** Lead with the life improved; earn the right to reveal architecture.
+2. **Relationships before inventory.** The connections between systems communicate more ambition than the number of projects.
+3. **Evidence before adjectives.** Demonstrate reliability, constraints, decisions, and iteration instead of repeatedly saying “intelligent” or “innovative.”
+4. **One moment of magic.** Concentrate cinematic craft in the ecosystem scenario; keep the rest calm and fast.
+5. **A person, not a persona.** Microsoft is context. Interests create warmth. The work and point of view remain the center.
+
+## Final Decision Filter
+
+> Does this make the system clearer, the judgment more credible, or the person more memorable?
+
+If the answer is no, remove it—even if the effect is technically impressive.
+
+## Composition Principles
+
+1. **Asymmetry must explain importance.** The larger field carries the thesis; smaller adjacent artifacts provide evidence or annotation.
+2. **One active plane per viewport.** Only one surface may behave like an instrument at a time.
+3. **Labels remain tethered.** Metadata belongs to an object edge or ledger line. Nothing floats as decorative UI.
+4. **Copy and signal never cross.** Body text must never sit inside moving diagrams or under connector lines.
+5. **Corners reveal material.** Paper corners are restrained; instrument corners feel machined. Avoid pill shapes except true state controls.
+6. **Depth comes from occlusion.** Use overlap, value, and framing. Heavy shadows and blurred glass make the environment feel synthetic.
+7. **Color follows responsibility.** Cobalt means active intelligence; amber means human judgment. Neither is decorative.
+8. **Every room contains a trace of use.** A note, timestamp, revision, checksum, or imperfection keeps the place inhabited.
+
+## The Long Table Composition Contract
+
+1. **One horizontal datum.** Every room visibly belongs to the same long working surface.
+2. **Warm bench, dark instrument.** Reading and evidence live on the bench; active system behavior lives in one bounded instrument plane.
+3. **One focal object per room.** Hierarchy must remain obvious before details are read.
+4. **Objects accumulate with provenance.** Artifacts carry system, state, date, and reason for inclusion.
+5. **Silence separates density.** The page provides space after the system demonstration and before the invitation.
+
+## Physical Logic
+
+1. **Protect the physical logic.** Everything must be placed, inset, clipped, written, aligned, or connected. Nothing floats without a reason.
+2. **Avoid the 3D demo trap.** The table is a compositional system first. Depth supports hierarchy; it is never a game environment.
+3. **Make the bench unmistakable.** Its proportion, rail, glass bay, checksum marks, and object spacing should form a repeatable signature.
+4. **Design an equivalent reading path.** The environment must remain coherent with reduced motion, keyboard navigation, and no perspective effects.
+
+## Rhythm and Density Principles
+
+1. **Rooms, not stripes.** Each major section should feel like entering a distinct work area with its own scale and purpose.
+2. **Sparse → precise → silent.** Open with space, build to relational density, then provide a full visual exhale.
+3. **Museum distance.** An object and its label remain intimate; unrelated objects receive enough space to become separate thoughts.
+4. **One dense room at a time.** Never place architecture, motion, personal imagery, and long copy in the same visual field.
+
+## Lighting Principles
+
+1. **Museum light, not screen glow.** Objects feel illuminated from the environment. The page does not appear to emit white light from every surface.
+2. **One brightest idea per view.** The eye should always know what the room is presenting. Secondary surfaces step back by value, not blur.
+3. **Light reveals state.** A dormant instrument is charcoal and quiet. Activation raises local contrast only around the responsible path.
+4. **No theatrical darkness.** Near-black appears in bounded instrument wells. Reading surfaces remain warm and generous.
+
+## Typography Principles
+
+1. **Sentence case carries confidence.** Avoid interface shouting. Uppercase belongs to tiny engraved labels only.
+2. **Short lines feel authored.** Body copy should read like a museum caption or thoughtful field note, not a marketing column.
+3. **Numbers become architecture.** Use tabular numerals for time, states, versions, and sequences; they create rhythm without ornament.
+4. **Headlines make claims, not introductions.** No oversized name, generic greeting, or stack of vague adjectives.
+5. **Monospace is metadata.** Reserve mono for timestamps, agent states, diagram labels, and system notation. Paragraphs in mono would turn the site into costume.
+
+## Motion Principles
+
+### Motion is the visible transfer of responsibility.
+
+Nothing “comes alive” on its own. Motion begins with intent, travels through a relationship, changes a state, and settles.
+
+1. **Intent causes motion.** No ambient performance and no decorative restlessness.
+2. **Responsibility moves in order.** Initiator, transfer, receiver, consequence.
+3. **Selection persists.** The visitor’s chosen scenario and reading depth remain stable while inspecting.
+4. **Evidence stays anchored.** Annotation changes around a primary artifact without displacing it.
+5. **The page remains a website.** Navigation, links, reading, and contact are direct even when the environment is expressive.
+
+### Causal Choreography
+
+1. **Intent.** The initiating object acknowledges the visitor with a brief compression or contrast change.
+2. **Commit.** A small registration mark locks in, showing that the request has become system work.
+3. **Transfer.** A line draws from source to receiver at constant visual speed. Direction is unmistakable.
+4. **Response.** The receiving label sharpens, then its local evidence appears. It never activates before the signal arrives.
+5. **Settle.** The connector fades to a structural trace while the resulting state remains. History is quieter than action.
+
+### Acceleration and Easing
+
+1. **Controls are decisive.** Fast departure, short travel, firm landing. No elastic overshoot and no playful bounce in system behavior.
+2. **Signals travel evenly.** A transfer line should feel measured, not theatrical. Constant visual velocity makes causality readable.
+3. **Objects arrive softly.** Revealed information decelerates into position as if placed by hand, not launched by software.
+4. **Parallel work looks parallel.** Only genuinely simultaneous systems may activate together; sequence is the visual grammar of dependency.
+
+### Timing Tiers
+
+| Duration | Tier | Purpose |
+|---|---|---|
+| 90–140ms | Contact | Press, focus, selection, and tiny state acknowledgment. Immediate; never bouncy. |
+| 180–260ms | Interface | Labels, panels, filters, and local reveals. Fast departure, soft landing. |
+| 320–480ms | Relationship | A dependency becomes visible or one agent activates another. Enough time to read causality. |
+| 700–1100ms | Narrative | Reserved for the one orchestration sequence or a major change of environment. Used once, not everywhere. |
+
+### The Motion Rule
+
+> Initiator first. Relationship second. Receiver third. Consequence last.
+
+If the order is different, the system will look magical instead of intelligent.
+
+## Interaction Principles
+
+1. **Focus reveals relevance.** Hover and keyboard focus clarify related objects while unrelated information recedes slightly.
+2. **Selection changes the room.** A chosen scenario persists until dismissed. The environment should not reset because the pointer moved away.
+3. **Exploration is layered.** The first interaction reveals behavior; a second may reveal a decision; architecture remains an intentional deeper step.
+4. **The cursor stays ordinary.** Craft belongs to the environment and response—not a custom pointer chasing the visitor.
+5. **Delight reveals intelligence.** Every memorable interaction must explain a relationship, reward curiosity, or reveal John’s point of view.
+
+## Evidence Principles
+
+1. **Show only what is real.** Use actual outputs and states; redact sensitive details without recreating a cleaner fiction.
+2. **Choose explanatory artifacts.** A rough diagram with a consequential decision outranks a polished screenshot with no story.
+3. **Preserve evidence of change.** Annotations, dates, and rejected versions make accumulated work visible.
+4. **State maturity plainly.** In daily use, On the bench, Under test, or Retired with lessons.
+5. **Artifacts are assembled, not carded.** Supporting evidence sits in a deliberate relationship around one primary piece of work.
+6. **Evidence has provenance.** Every artifact carries system, state, date, and reason for inclusion.
+
+## Human Storytelling Principles
+
+1. **Personal details are discovered.** John appears through the artifacts he keeps, the observations he records, and the values that cross from life into system design.
+2. **Three artifacts at once.** The human layer remains edited and spatially calm.
+3. **One sentence per artifact.** Personal notes should reward curiosity without becoming captions for a lifestyle feed.
+4. **Connect life to judgment.** Every artifact reveals attention, ritual, craft, movement, sound, or changed belief.
+5. **No feeds or counters.** The person is present through meaning, not activity volume.
+6. **Microsoft is identity, not borrowed brand.** The portfolio must establish John’s independent point of view.
+
+## Jarvis Principles
+
+1. Jarvis is the coordinating layer, not one project among many.
+2. Jarvis interprets intent and coordinates specialized capabilities.
+3. Jarvis carries context between capabilities and preserves system orientation.
+4. Jarvis becomes central through relationships, not visual size.
+5. Jarvis never becomes a face, glowing orb, voice waveform, superhero reference, floating assistant, mascot, generic chatbot, or replacement for clear navigation.
+
+## Where to Take a Bigger Risk
+
+1. **Remove the conventional project grid.** Let the one-day scenario become the homepage’s primary navigation into work.
+2. **Show an unfinished edge.** A visible decision ledger and honest project states are more distinctive than another polished mockup.
+3. **Cross the environmental threshold.** Allow one clear transition from warm bench into dark instrument.
+4. **Include one personal sensory artifact.** A field recording or travel observation adds more authorship than a louder hero animation.
+
+## Where Not to Take the Risk
+
+1. **Not in legibility.** Typography, contrast, navigation, and reduced motion remain exceptionally conventional.
+2. **Not in fake intelligence.** The system may be authored and demonstrative; it must never imply real-time agency it does not have.
+3. **Not in visual noise.** The environment earns distinction through material contrast and behavior, not more particles, glows, and layers.
+4. **Not in fan-service.** Jarvis is a system role, not a Marvel reference.
+
+## Absolute Exclusions
+
+1. “Hi, I’m John” as the primary idea.
+2. A six-card project grid where every project appears equally important.
+3. Skill bars, logo clouds, contribution graphs, or a giant technology inventory.
+4. Fake terminals, fake system logs, fake live users, or fabricated telemetry.
+5. A free-form AI chatbot with no designed purpose.
+6. Scroll-jacking, mandatory horizontal scroll, or constant parallax.
+7. Custom cursors, autoplay audio, excessive glass blur, or glow on every edge.
+8. Dark mode as a substitute for cinematic art direction.
+9. Microsoft as the story rather than one signal of credibility.
+10. Confidential workplace details or claims that cannot be demonstrated.
+11. Pixel art used as the whole aesthetic instead of a trace of lineage.
+12. Resume chronology before the visitor understands the body of work.
+
+## Things We Must Never Do
+
+1. Never personify Jarvis with a face, glowing orb, voice waveform, or superhero mythology.
+2. Never illuminate every edge. Light indicates attention or transferred responsibility.
+3. Never place body copy over an active system visualization.
+4. Never let a connector cross text, another connector, or an unrelated object.
+5. Never make every section full-screen; cinematic scale without intimacy becomes monotonous.
+6. Never use glass blur as the default material. Glass is an aperture, not wallpaper.
+7. Never animate because the page is idle. A living system is responsive, not restless.
+8. Never use a technology logo as visual proof of engineering depth.
+9. Never let Microsoft’s brand colors, language, or prestige determine John’s identity.
+10. Never use “futuristic” as permission for illegible contrast, tiny type, or ambiguous controls.
+11. Never flatten experiments and mature systems into the same level of finish.
+12. Never add an effect that cannot explain what caused it.
+
+## Longevity Principles
+
+1. **Materials, not trends.** Paper, metal, glass, ink, and light are durable references.
+2. **Semantic behavior.** Motion represents intent, transfer, response, and consequence.
+3. **The identity can absorb new eras.** New agents, products, research, or companies enter the Bench / Instrument grammar.
+4. **Evidence replaces hype.** Decisions, limits, and outcomes remain credible when current AI language becomes dated.
+5. **History remains visible.** The checksum and archive turn previous aesthetics into lineage rather than embarrassment.
+
+## Related Documents
+
+- [Product Blueprint](./01-product-blueprint.md)
+- [Creative Direction](./03-creative-direction.md)
+- [Homepage Specification](./05-homepage-specification.md)

--- a/docs/design/07-open-questions.md
+++ b/docs/design/07-open-questions.md
@@ -1,0 +1,128 @@
+# Open Questions
+
+This document preserves the unresolved questions and required source material identified during the design process. It introduces no new design direction.
+
+## Strategic Questions
+
+### 1. What can be shown truthfully?
+
+Identify working demos, real outputs, and architecture details that are safe to publish.
+
+### 2. Which three stories have the strongest judgment?
+
+Choose depth over project count. A weaker project should remain in the lab index.
+
+### 3. What is Jarvis today?
+
+Define its actual orchestration role, boundaries, and maturity so the narrative does not outrun the product.
+
+### 4. How personal should the site become?
+
+Decide which travel, health, audio, and daily-life artifacts reveal motivation without becoming lifestyle content.
+
+### 5. What is the future container?
+
+Choose whether AI-Lab remains a personal R&D identity or may eventually become a studio/company brand.
+
+## Required Content Before Visual Production
+
+### System Truth
+
+Collect:
+
+- Current Jarvis role.
+- Agent responsibilities.
+- Capability maturity states.
+- Real handoffs.
+- Automation boundaries.
+- Architecture details safe to publish.
+- Claims that can be demonstrated honestly.
+
+### Three Authored Scenarios
+
+Prepare:
+
+1. **Plan travel**
+2. **Protect time**
+3. **Understand wellbeing**
+
+Each scenario needs:
+
+- Human intention.
+- Inputs and context.
+- Participating systems.
+- Responsibility sequence.
+- Decisions.
+- Outputs.
+- Uncertainty.
+- Human confirmation points.
+- Final outcome.
+
+### Evidence Assemblies
+
+Prepare at least four strong primary artifacts.
+
+Each artifact needs:
+
+- A meaningful decision.
+- Provenance.
+- System.
+- Maturity state.
+- Date or revision.
+- One supporting trace of iteration.
+- A safe-to-publish Experience view.
+- A safe-to-publish Decisions view.
+- A safe-to-publish Architecture view.
+
+Candidate source material:
+
+- Actual outputs.
+- Architecture sketches.
+- Design decisions.
+- Tradeoffs.
+- Failed experiments.
+- Deployment notes.
+- Screenshots.
+- Diagrams.
+- Meaningful commit excerpts.
+- Engineering notebook pages.
+
+### Human Artifacts
+
+Prepare:
+
+- A California or travel photograph with a field note.
+- A field recording or piece of audio hardware.
+- A book with one marked passage and John’s margin response.
+- A Sunday Pasta Co. object: label, recipe card, packaging proof, or serving ritual.
+- An engineering notebook page titled “What surprised me.”
+- One restrained, unstaged image of John or his hand at work.
+- A short Microsoft maker label that communicates scale without confidential detail or borrowed branding.
+
+## Content Verification Questions
+
+Before an artifact is included:
+
+1. Is it real?
+2. Can it be published safely?
+3. Does it explain a human outcome, consequential decision, or system relationship?
+4. Is its maturity state stated honestly?
+5. Does it include provenance?
+6. Does it show judgment rather than activity volume?
+7. Would a rougher artifact explain the work better than a polished screenshot?
+
+## Selection Questions
+
+For each homepage object:
+
+1. Does it make the system clearer?
+2. Does it make the judgment more credible?
+3. Does it make the person more memorable?
+
+If the answer to all three is no, remove it.
+
+## Related Documents
+
+- [Product Blueprint](./01-product-blueprint.md)
+- [Homepage Specification](./05-homepage-specification.md)
+- [Design Principles](./06-design-principles.md)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,95 @@
+# Portfolio Design Documentation
+
+This directory contains the permanent design foundation for John Moses’s portfolio.
+
+The documents preserve the product strategy, information architecture, creative direction, visual-world exploration, canonical Long Table decision, homepage product specification, principles, and unresolved content questions developed before implementation.
+
+## Canonical Status
+
+The following decisions are locked:
+
+- The portfolio presents one connected ecosystem, not a collection of independent projects.
+- AI-Lab is the umbrella system.
+- Jarvis is the coordinating layer.
+- The product promise is **“Everyday life, thoughtfully automated.”**
+- The creative direction is **The Luminous Workshop**.
+- The canonical visual metaphor is **The Long Table**.
+- The homepage narrative is **Arrival → Discovery → Understanding → Evidence → Judgment → Person → Invitation**.
+
+Do not revisit these decisions unless they conflict with validated product or implementation constraints.
+
+## Reading Order
+
+### 1. [00-overview.md](./00-overview.md)
+
+Start here.
+
+Provides the canonical north star, locked decisions, system model, homepage narrative, and links to the full foundation.
+
+### 2. [01-product-blueprint.md](./01-product-blueprint.md)
+
+Defines the product story, emotional journey, 10-second test, interaction philosophy, original creative directions, and selected strategic blend.
+
+### 3. [02-information-architecture.md](./02-information-architecture.md)
+
+Defines AI-Lab, Jarvis’s role, capability grouping, homepage sequence, project hierarchy, case-study structure, evidence architecture, and navigation model.
+
+### 4. [03-creative-direction.md](./03-creative-direction.md)
+
+Defines The Luminous Workshop: atmosphere, lighting, materials, shape language, typography, motion, signature moments, hidden details, prohibitions, and the 2035 aging test.
+
+### 5. [04-visual-world-exploration.md](./04-visual-world-exploration.md)
+
+Preserves the six explored visual worlds, their strengths and failure modes, the ranking, and the selection of The Long Table.
+
+This is historical design context. The alternatives are not active directions.
+
+### 6. [05-homepage-specification.md](./05-homepage-specification.md)
+
+The primary build-facing product document.
+
+Defines all seven homepage chapters, including purpose, emotional goal, visual hierarchy, visitor learning, interaction, stillness, motion, content, narrative transitions, evidence model, human layer, navigation, and handoff contracts.
+
+### 7. [06-design-principles.md](./06-design-principles.md)
+
+Collects the canonical product, composition, lighting, typography, motion, interaction, evidence, human-storytelling, Jarvis, and longevity principles in one reference.
+
+Use this document to review visual and interaction decisions.
+
+### 8. [07-open-questions.md](./07-open-questions.md)
+
+Tracks unresolved source-material and content questions without introducing new design direction.
+
+Use this document before visual production and implementation to gather real scenarios, evidence, architecture details, and personal artifacts.
+
+## How to Use These Documents
+
+### Product and design review
+
+Use [00-overview.md](./00-overview.md) and [06-design-principles.md](./06-design-principles.md) as the review filter.
+
+### Homepage design
+
+Use [05-homepage-specification.md](./05-homepage-specification.md) as the source of truth, supported by [03-creative-direction.md](./03-creative-direction.md).
+
+### Content collection
+
+Use [07-open-questions.md](./07-open-questions.md) to gather real source material. Do not fabricate telemetry, outputs, decisions, or maturity.
+
+### System and case-study structure
+
+Use [02-information-architecture.md](./02-information-architecture.md) for the ecosystem model, capability hierarchy, evidence types, and return paths.
+
+### Historical rationale
+
+Use [01-product-blueprint.md](./01-product-blueprint.md) and [04-visual-world-exploration.md](./04-visual-world-exploration.md) to understand why the canonical direction was selected.
+
+## Final Decision Filter
+
+> Does this make the system clearer, the judgment more credible, or the person more memorable?
+
+If the answer is no, remove it—even if the effect is technically impressive.
+
+## Repository Note
+
+A `.gitkeep` file is not required because this directory contains tracked documentation files.


### PR DESCRIPTION
## Summary
- preserve the canonical portfolio product blueprint and information architecture
- archive the Luminous Workshop creative direction and six-world exploration, including The Long Table selection
- document the complete homepage specification, governing principles, and unresolved content questions

## Test plan
- [x] Verify all nine Markdown documents are present under `docs/design/`
- [x] Verify cross-links and Mermaid diagrams use repository-relative paths
- [x] Run `git diff --check`
- [x] Confirm the pre-existing `portfolio/package-lock.json` change is excluded


Made with [Cursor](https://cursor.com)